### PR TITLE
feat(snacks): Add session restore action to dashboard

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -62,4 +62,6 @@ require("lazy").setup({
 })
 
 require("utils.hooks").setup()
+require("utils.patches").setup()
 require("config/keymaps")
+

--- a/lua/plugins/snacks.lua
+++ b/lua/plugins/snacks.lua
@@ -35,9 +35,6 @@ return {
           {
             section = "projects",
             padding = 1,
-            action = function(dir)
-              vim.fn.chdir(dir)
-            end,
           },
           {
             section = "keys",

--- a/lua/utils/patches.lua
+++ b/lua/utils/patches.lua
@@ -1,0 +1,14 @@
+local M = {}
+
+function M.setup()
+  local snacks = require("snacks")
+
+  snacks.dashboard.sections.session = function(item)
+    return setmetatable({
+      action = ":silent! SessionRestore",
+      section = false,
+    }, { __index = item })
+  end
+end
+
+return M


### PR DESCRIPTION
Create a patch module to override the behavior of the `snacks` dashboard.