### PR TITLE
feat: add xkbswitch.nvim

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -63,5 +63,8 @@ require("lazy").setup({
 
 require("utils.hooks").setup()
 require("utils.patches").setup()
+require('xkbswitch').setup()
+
 require("config/keymaps")
+
 

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -48,5 +48,6 @@
   "vim-repeat": { "branch": "master", "commit": "65846025c15494983dafe5e3b46c8f88ab2e9635" },
   "vim-rhubarb": { "branch": "master", "commit": "5496d7c94581c4c9ad7430357449bb57fc59f501" },
   "vim-startuptime": { "branch": "master", "commit": "b6f0d93f6b8cf6eee0b4c94450198ba2d6a05ff6" },
-  "which-key.nvim": { "branch": "main", "commit": "370ec46f710e058c9c1646273e6b225acf47cbed" }
+  "which-key.nvim": { "branch": "main", "commit": "370ec46f710e058c9c1646273e6b225acf47cbed" },
+  "xkbswitch.nvim": { "branch": "master", "commit": "aae56d49db9baf0d9b9675a77da35173d8d87a30" }
 }

--- a/lua/plugins/auto-save.lua
+++ b/lua/plugins/auto-save.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/auto-save.lua
+
 return {
   "okuuva/auto-save.nvim",
   event = { "InsertLeave", "TextChanged" },

--- a/lua/plugins/auto-session.lua
+++ b/lua/plugins/auto-session.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/auto-session.lua
+
 return {
   'rmagatti/auto-session',
   lazy = false,

--- a/lua/plugins/bufferline.lua
+++ b/lua/plugins/bufferline.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/bufferline.lua
+
 return {
   "akinsho/bufferline.nvim",
   version = "*",

--- a/lua/plugins/comment.lua
+++ b/lua/plugins/comment.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/comment.lua
+
 return {
   "numToStr/Comment.nvim",
   event = { "BufReadPre", "BufNewFile" },

--- a/lua/plugins/conform.lua
+++ b/lua/plugins/conform.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/conform.lua
+
 return {
   "stevearc/conform.nvim",
   event = { "BufWritePre" },

--- a/lua/plugins/copilot-cmp.lua
+++ b/lua/plugins/copilot-cmp.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/copilot-cmp.lua
+
 return {
   "zbirenbaum/copilot-cmp",
   dependencies = { "copilot.lua" },

--- a/lua/plugins/copilot-lualine.lua
+++ b/lua/plugins/copilot-lualine.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/copilot-lualine.lua
+
 return {
   "AndreM222/copilot-lualine",
 }

--- a/lua/plugins/copilot.lua
+++ b/lua/plugins/copilot.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/copilot.lua
+
 return {
   "zbirenbaum/copilot.lua",
   cmd = "Copilot",

--- a/lua/plugins/fugitive.lua
+++ b/lua/plugins/fugitive.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/fugitive.lua
+
 return {
   "tpope/vim-fugitive",
   cmd = {

--- a/lua/plugins/gitsigns.lua
+++ b/lua/plugins/gitsigns.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/gitsigns.lua
+
 return {
   "lewis6991/gitsigns.nvim",
   event = { "BufReadPost", "BufNewFile" },

--- a/lua/plugins/indent-blankline.lua
+++ b/lua/plugins/indent-blankline.lua
@@ -1,4 +1,4 @@
--- File: lua/plugins/indent-blankline.lua
+-- lua/plugins/indent-blankline.lua
 
 return {
   "lukas-reineke/indent-blankline.nvim",

--- a/lua/plugins/leap.lua
+++ b/lua/plugins/leap.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/leap.lua
+
 return {
   "ggandor/leap.nvim",
   event = "VeryLazy",

--- a/lua/plugins/lualine.lua
+++ b/lua/plugins/lualine.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/lualine.lua
+
 return {
   "nvim-lualine/lualine.nvim",
   dependencies = {

--- a/lua/plugins/luasnip.lua
+++ b/lua/plugins/luasnip.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/luasnip.lua
+
 return {
   "L3MON4D3/LuaSnip",
   dependencies = { "rafamadriz/friendly-snippets" },

--- a/lua/plugins/noice.lua
+++ b/lua/plugins/noice.lua
@@ -1,4 +1,4 @@
--- File: lua/plugins/noice.lua
+-- lua/plugins/noice.lua
 
 return {
   "folke/noice.nvim",

--- a/lua/plugins/nvim-autopairs.lua
+++ b/lua/plugins/nvim-autopairs.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/nvim-autopairs.lua
+
 return {
   "windwp/nvim-autopairs",
   event = "InsertEnter",

--- a/lua/plugins/nvim-cmp.lua
+++ b/lua/plugins/nvim-cmp.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/nvim-cmp.lua
+
 return {
   "hrsh7th/nvim-cmp",
   event = "InsertEnter",

--- a/lua/plugins/nvim-dap.lua
+++ b/lua/plugins/nvim-dap.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/nvim-dap.lua
+
 return {
   "mfussenegger/nvim-dap",
   dependencies = {

--- a/lua/plugins/nvim-lint.lua
+++ b/lua/plugins/nvim-lint.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/nvim-lint.lua
+
 return {
   "mfussenegger/nvim-lint",
   event = { "BufReadPre", "BufNewFile" },

--- a/lua/plugins/nvim-lspconfig.lua
+++ b/lua/plugins/nvim-lspconfig.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/nvim-lspconfig.lua
+
 return {
   "neovim/nvim-lspconfig",
   lazy = false,

--- a/lua/plugins/nvim-treesitter-context.lua
+++ b/lua/plugins/nvim-treesitter-context.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/nvim-treesitter-context.lua
+
 return {
   "nvim-treesitter/nvim-treesitter-context",
   dependencies = { "nvim-treesitter/nvim-treesitter" },

--- a/lua/plugins/nvim-treesitter-textobjects.lua
+++ b/lua/plugins/nvim-treesitter-textobjects.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/nvim-treesitter-textobjects.lua
+
 return {
   "nvim-treesitter/nvim-treesitter-textobjects",
   dependencies = { "nvim-treesitter/nvim-treesitter" },

--- a/lua/plugins/nvim-treesitter.lua
+++ b/lua/plugins/nvim-treesitter.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/nvim-treesitter.lua
+
 return {
   "nvim-treesitter/nvim-treesitter",
   event = { "BufReadPost", "BufNewFile" },

--- a/lua/plugins/snacks.lua
+++ b/lua/plugins/snacks.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/snacks.lua
+
 return {
   "folke/snacks.nvim",
   event = "VeryLazy",

--- a/lua/plugins/tokyonight.lua
+++ b/lua/plugins/tokyonight.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/tokyonight.lua
+
 return {
   "folke/tokyonight.nvim",
   lazy = false,

--- a/lua/plugins/vim-startuptime.lua
+++ b/lua/plugins/vim-startuptime.lua
@@ -1,3 +1,5 @@
+-- lua/plugins/vim-startuptime.lua
+
 return {
   "dstein64/vim-startuptime",
   cmd = "StartupTime",

--- a/lua/plugins/which-key.lua
+++ b/lua/plugins/which-key.lua
@@ -1,4 +1,5 @@
 -- lua/plugins/which-key.lua
+
 return {
   "folke/which-key.nvim",
   event = "VeryLazy",

--- a/lua/plugins/xkbswitch.lua
+++ b/lua/plugins/xkbswitch.lua
@@ -1,0 +1,8 @@
+-- lua/plugins/xkbswitch.lua
+
+return {
+  {
+    'ivanesmantovich/xkbswitch.nvim',
+    lazy = false
+  }
+}


### PR DESCRIPTION
Adds the xkbswitch.nvim plugin to automatically save and restore the keyboard layout when switching between insert and normal modes.

Also, adds file path comments to all plugin configuration files for consistency.