### PR TITLE
fix(copilot): use theme comment color for ghost text and prevent cmp from intercepting C-y

### DIFF
--- a/lua/plugins/nvim-cmp.lua
+++ b/lua/plugins/nvim-cmp.lua
@@ -12,7 +12,7 @@
 --   <C-Space>  - Trigger completion manually
 --
 -- COPILOT (separate - inline gray text, NEVER used by popup):
---   <C-y>      - Accept full Copilot suggestion
+--   <C-y>      - Accept full Copilot suggestion (never intercepted by cmp)
 --   <C-g>      - Accept next word
 --   <C-n>      - Next Copilot suggestion (reserved for Copilot only)
 --   <C-p>      - Previous Copilot suggestion (reserved for Copilot only)
@@ -136,6 +136,11 @@ return {
         end, { "i", "s" }),
         
         ["<C-p>"] = cmp.mapping(function(fallback)
+          fallback() -- Always pass through to Copilot
+        end, { "i", "s" }),
+        
+        -- Disable C-y for popup (reserved for Copilot accept)
+        ["<C-y>"] = cmp.mapping(function(fallback)
           fallback() -- Always pass through to Copilot
         end, { "i", "s" }),
         

--- a/lua/plugins/themes.lua
+++ b/lua/plugins/themes.lua
@@ -587,6 +587,17 @@ local github = {
   end,
 }
 
+-- Ensure Copilot ghost text uses the theme's Comment color (muted, visually distinct)
+vim.api.nvim_create_autocmd("ColorScheme", {
+  pattern = "*",
+  callback = function()
+    local comment_hl = vim.api.nvim_get_hl(0, { name = "Comment", link = false })
+    local fg = comment_hl.fg
+    vim.api.nvim_set_hl(0, "CopilotSuggestion", { fg = fg, italic = true })
+    vim.api.nvim_set_hl(0, "CopilotAnnotation", { fg = fg, italic = true })
+  end,
+})
+
 -- Return all themes
 return {
   catppuccin,


### PR DESCRIPTION
## Summary

- Set `CopilotSuggestion`/`CopilotAnnotation` highlight groups to the active theme's `Comment` fg color via a `ColorScheme` autocmd, so ghost text is always visually distinct from normal code across all supported themes
- Override `<C-y>` in nvim-cmp to always fall through, preventing the completion popup from swallowing the Copilot accept-suggestion binding