### PR TITLE
fix(render): fix partial redraw glitches in Zellij and other multiplexers

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -8,6 +8,8 @@ local opt = vim.opt
 
 opt.updatetime = 250
 opt.timeoutlen = 300
+opt.ttimeout = true
+opt.ttimeoutlen = 10
 opt.redrawtime = 1500
 opt.synmaxcol = 240
 
@@ -15,7 +17,18 @@ opt.number = true
 opt.relativenumber = true
 opt.signcolumn = "yes"
 opt.cursorline = true
-opt.termguicolors = true
+-- Enable true-color only when the terminal supports it.
+-- Zellij and tmux may report TERM=xterm-256color without COLORTERM=truecolor,
+-- which causes partial-redraw glitches when termguicolors is forced on.
+local colorterm = vim.env.COLORTERM
+local term = vim.env.TERM or ""
+local has_truecolor = colorterm == "truecolor"
+  or colorterm == "24bit"
+  or term:find("kitty") ~= nil
+  or term:find("alacritty") ~= nil
+  or vim.env.TERM_PROGRAM == "iTerm.app"
+  or vim.env.TERM_PROGRAM == "ghostty"
+opt.termguicolors = has_truecolor
 opt.background = "dark"
 opt.laststatus = 3
 opt.cmdheight = 1

--- a/lua/utils/hooks.lua
+++ b/lua/utils/hooks.lua
@@ -39,11 +39,13 @@ local function update_title()
     filename = "[No Name]"
   end
 
-  -- Detect if we're in tmux
+  -- Detect multiplexer: tmux uses $TMUX, zellij uses $ZELLIJ
   local in_tmux = vim.env.TMUX ~= nil
+  local in_zellij = vim.env.ZELLIJ ~= nil
+  local in_multiplexer = in_tmux or in_zellij
 
-  if in_tmux then
-    -- Short format for tmux: "filename+RO [N]"
+  if in_multiplexer then
+    -- Short format for multiplexers: "filename+RO [N]"
     local status = table.concat({ modified, readonly }, "")
     if status ~= "" then
       status = status .. " "


### PR DESCRIPTION
## Problem

Neovim renders incompletely (ghost symbols, parts of screen not redrawn) when running inside Zellij.

## Root Causes

1. **Missing `ttimeoutlen`** — without it, Neovim waits indefinitely for terminal escape sequence responses. Zellij adds latency to these responses, causing partial redraws.
2. **Unconditional `termguicolors = true`** — Zellij typically sets `TERM=xterm-256color` without `COLORTERM=truecolor`. Sending 24-bit color escape sequences to a terminal that didn't advertise truecolor support causes rendering artifacts.
3. **No Zellij detection in `hooks.lua`** — the code only checked `$TMUX`, so under Zellij it generated a long `titlestring` with `user@host` as if no multiplexer was present.

## Changes

- `lua/config/options.lua`: add `ttimeout = true` and `ttimeoutlen = 10` (10ms is the standard value for multiplexer environments)
- `lua/config/options.lua`: make `termguicolors` conditional — enabled only when `COLORTERM=truecolor/24bit`, or when running in kitty/alacritty/iTerm2/ghostty
- `lua/utils/hooks.lua`: detect Zellij via `$ZELLIJ` env var alongside existing `$TMUX` detection