### PR TITLE
fix: improve Zellij compatibility and general health fixes

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -7,6 +7,7 @@ indent_type = "Spaces"
 indent_width = 2
 quote_style = "AutoPreferDouble"
 call_parentheses = "Always"
+syntax = "Lua52"
 
 [sort_requires]
 enabled = false

--- a/bin/test-config.sh
+++ b/bin/test-config.sh
@@ -162,15 +162,33 @@ test_treesitter() {
 # Test: Keymap conflicts
 test_keymap_conflicts() {
     log_test "Checking for keymap conflicts..."
-    
-    nvim --headless "+lua require('meowvim.keymap_checker').show_conflicts()" "+write $TEST_OUTPUT/conflicts.txt" +qa 2>&1
-    
-    if [ -f "$TEST_OUTPUT/conflicts.txt" ] && grep -q "No keymap conflicts" "$TEST_OUTPUT/conflicts.txt"; then
+
+    local lua_script='
+local conflicts = require("meowvim.keymap_checker").get_conflicts()
+if #conflicts == 0 then
+  io.write("No keymap conflicts\n")
+else
+  io.write(string.format("Found %d conflicts:\n", #conflicts))
+  for _, c in ipairs(conflicts) do
+    io.write(string.format("  [%s] %s\n", c.mode, c.lhs))
+  end
+end
+'
+    local output
+    output=$(nvim --headless "+lua $lua_script" +qa 2>&1)
+
+    if echo "$output" | grep -q "^No keymap conflicts"; then
         log_success "No keymap conflicts detected"
         return 0
+    elif echo "$output" | grep -q "^Found"; then
+        local count
+        count=$(echo "$output" | grep -o 'Found [0-9]* conflicts' | grep -o '[0-9]*')
+        log_error "Found $count keymap conflicts:"
+        echo "$output" | grep -v "^Found" | head -20
+        return 1
     else
-        log_info "Keymap conflicts may exist (check output)"
-        return 0  # Not a failure, just informational
+        log_info "Keymap conflict check inconclusive (headless output not captured)"
+        return 0
     fi
 }
 

--- a/init.lua
+++ b/init.lua
@@ -6,6 +6,12 @@
 
 vim.loader.enable()
 
+-- Disable all providers — no plugins in this config require them
+vim.g.loaded_python3_provider = 0
+vim.g.loaded_ruby_provider = 0
+vim.g.loaded_perl_provider = 0
+vim.g.loaded_node_provider = 0
+
 -- Add Mason bin to PATH
 local mason_bin = vim.fn.stdpath("data") .. "/mason/bin"
 if vim.fn.isdirectory(mason_bin) == 1 and not (vim.env.PATH or ""):find(mason_bin, 1, true) then

--- a/lua/config/keymaps.lua
+++ b/lua/config/keymaps.lua
@@ -245,9 +245,9 @@ local function flash_action(action_name, multi_window)
     local flash = safe_require("flash")
     if flash then
       if action_name == "jump" then
-        flash.jump({ 
+        flash.jump({
           search = { max_length = 2 },
-          multi_window = multi_window or false 
+          multi_window = multi_window or false,
         })
       elseif action_name == "treesitter" then
         flash.treesitter()
@@ -550,12 +550,16 @@ function M.setup()
       { "<leader>c", group = "Code", icon = "󰅩" },
       { "<leader>cc", vim.lsp.buf.code_action, desc = "Code Action", mode = { "n", "v" } },
       { "<leader>cr", vim.lsp.buf.rename, desc = "Rename Symbol" },
-      { "<leader>cf", function()
+      {
+        "<leader>cf",
+        function()
           require("conform").format({ async = true, lsp_fallback = true })
         end,
         desc = "Format Buffer",
       },
-      { "<leader>co", function()
+      {
+        "<leader>co",
+        function()
           local ft = vim.bo.filetype
           if ft ~= "typescript" and ft ~= "typescriptreact" and ft ~= "javascript" and ft ~= "javascriptreact" then
             vim.notify("Organize Imports is available in TypeScript and JavaScript buffers", vim.log.levels.WARN)
@@ -1042,10 +1046,10 @@ function M.setup()
         function()
           vim.g.copilot_enabled = not vim.g.copilot_enabled
           toggles.update("copilot_enabled")
-          
+
           if vim.g.copilot_enabled then
             -- Enable Copilot
-            local ok, copilot = pcall(require, "copilot")
+            local ok, _ = pcall(require, "copilot")
             if ok then
               vim.cmd("Copilot enable")
               vim.notify("Copilot: ON (restart may be needed)", vim.log.levels.INFO)
@@ -1069,7 +1073,7 @@ function M.setup()
         function()
           -- Sync current toggles to config
           toggles.sync_to_config()
-          
+
           -- Persist config to file
           local config = require("meowvim.config")
           if config.persist() then
@@ -1080,7 +1084,7 @@ function M.setup()
         end,
         desc = "Persist Settings",
       },
-      
+
       -- Theme Settings (simplified)
       {
         "<leader>ok",
@@ -1115,7 +1119,6 @@ function M.setup()
         end,
         desc = "Show Redo History",
       },
-
 
       {
         "<leader>uy",

--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -57,7 +57,7 @@ opt.incsearch = true
 
 opt.completeopt = { "menu", "menuone", "noselect" }
 opt.pumheight = 10
-opt.pumblend = 10
+opt.pumblend = 0
 
 opt.backup = false
 opt.writebackup = false
@@ -71,7 +71,7 @@ opt.splitbelow = true
 opt.clipboard:append("unnamedplus")
 
 opt.mouse = "a"
-opt.mousefocus = true
+opt.mousefocus = false
 
 -- Folding configuration (overridden by nvim-ufo plugin when loaded)
 -- Defaults to treesitter-based folding as fallback
@@ -86,7 +86,7 @@ opt.iskeyword:append("-")
 opt.formatoptions:remove({ "c", "r", "o" })
 opt.shortmess:append({ W = true, I = true, c = true, C = true })
 
-opt.sessionoptions = "buffers,curdir,folds,globals,tabpages,winpos,winsize,localoptions,resize"
+opt.sessionoptions = "buffers,curdir,folds,globals,tabpages,localoptions"
 
 opt.title = true
 opt.titlelen = 70
@@ -100,6 +100,16 @@ opt.spelloptions:append("camel")
 local spell_dir = vim.fn.stdpath("config") .. "/spell"
 vim.fn.mkdir(spell_dir, "p")
 opt.spellfile = spell_dir .. "/en.utf-8.add"
+
+-- Force a full redraw after terminal resize to prevent partial-redraw glitches
+-- under Zellij, tmux, and other multiplexers.
+vim.api.nvim_create_autocmd("VimResized", {
+  group = vim.api.nvim_create_augroup("meowvim-resize-redraw", { clear = true }),
+  callback = function()
+    vim.cmd("wincmd =")
+    vim.cmd("redraw!")
+  end,
+})
 
 local spell_group = vim.api.nvim_create_augroup("meowvim-spell", { clear = true })
 

--- a/lua/meowvim/colorscheme_switcher.lua
+++ b/lua/meowvim/colorscheme_switcher.lua
@@ -12,38 +12,54 @@ local themes = {
   catppuccin = { "mocha", "latte", "frappe", "macchiato" },
   tokyonight = { "storm", "night", "moon", "day" },
   ["rose-pine"] = { "main", "moon", "dawn" },
-  
+
   -- Warm & Natural
   everforest = { "dark_hard", "dark_medium", "dark_soft", "light_hard", "light_medium", "light_soft" },
   gruvbox = { "medium", "hard", "soft" },
-  
+
   -- Clean & Professional
   kanagawa = { "wave", "dragon", "lotus" },
   ["solarized-osaka"] = { "night", "storm", "moon", "day" },
-  
+
   -- Tech & High Contrast
   nightfox = { "nightfox", "dayfox", "dawnfox", "duskfox", "nordfox", "terafox", "carbonfox" },
-  
+
   -- Minimal & Focused
-  zenbones = { "zenbones", "zenwritten", "neobones", "tokyobones", "seoulbones", "forestbones", "nordbones", "kanagawabones", "rosebones" },
+  zenbones = {
+    "zenbones",
+    "zenwritten",
+    "neobones",
+    "tokyobones",
+    "seoulbones",
+    "forestbones",
+    "nordbones",
+    "kanagawabones",
+    "rosebones",
+  },
   ayu = { "dark", "light", "mirage" },
-  
+
   -- Classic Dark
   nord = {},
   dracula = {},
   melange = {},
-  
+
   -- Professional Studio
   ["monokai-pro"] = { "pro", "octagon", "machine", "ristretto", "spectrum", "classic" },
-  
+
   -- Developer Standard
   onedark = { "onedark", "onelight", "onedark_vivid", "onedark_dark" },
-  
+
   -- Material Design
   material = { "darker", "lighter", "oceanic", "palenight", "deep ocean" },
-  
+
   -- GitHub Official
-  github = { "github_dark", "github_dark_dimmed", "github_dark_high_contrast", "github_light", "github_light_high_contrast" },
+  github = {
+    "github_dark",
+    "github_dark_dimmed",
+    "github_dark_high_contrast",
+    "github_light",
+    "github_light_high_contrast",
+  },
 }
 
 -- Get base themes without variants (for main theme picker)
@@ -82,60 +98,37 @@ local function get_all_theme_options()
   return options
 end
 
-local function apply_theme(theme, variant)
-  -- Update config if available
-  local config_ok, config = pcall(require, "meowvim.config")
-  if config_ok then
-    config.set("core.theme", theme)
-    if variant then
-      config.set("core.variant", variant)
-    end
-  end
-  
-  -- Apply theme-specific configuration
-  if theme == "catppuccin" then
-    require("catppuccin").setup({
-      flavour = variant or "mocha",
-      transparent_background = false,
-    })
+local theme_appliers = {
+  catppuccin = function(variant)
+    require("catppuccin").setup({ flavour = variant or "mocha", transparent_background = false })
     vim.cmd.colorscheme("catppuccin")
-  elseif theme == "tokyonight" then
-    require("tokyonight").setup({
-      style = variant or "storm",
-      transparent = false,
-    })
+  end,
+  tokyonight = function(variant)
+    require("tokyonight").setup({ style = variant or "storm", transparent = false })
     vim.cmd.colorscheme("tokyonight")
-  elseif theme == "rose-pine" then
-    require("rose-pine").setup({
-      variant = variant or "main",
-      styles = {
-        transparency = false,
-      },
-    })
+  end,
+  ["rose-pine"] = function(variant)
+    require("rose-pine").setup({ variant = variant or "main", styles = { transparency = false } })
     vim.cmd.colorscheme("rose-pine")
-  elseif theme == "gruvbox" then
-    require("gruvbox").setup({
-      contrast = variant or "medium",
-      transparent_mode = false,
-    })
+  end,
+  gruvbox = function(variant)
+    require("gruvbox").setup({ contrast = variant or "medium", transparent_mode = false })
     vim.o.background = "dark"
     vim.cmd.colorscheme("gruvbox")
-  elseif theme == "nord" then
+  end,
+  nord = function(_)
     vim.g.nord_contrast = true
     vim.g.nord_borders = true
     vim.g.nord_disable_background = false
     vim.cmd.colorscheme("nord")
-  elseif theme == "kanagawa" then
-    require("kanagawa").setup({
-      theme = variant or "wave",
-      transparent = false,
-    })
+  end,
+  kanagawa = function(variant)
+    require("kanagawa").setup({ theme = variant or "wave", transparent = false })
     vim.cmd.colorscheme("kanagawa")
-  elseif theme == "everforest" then
-    -- Parse variant: format is "background_style" (e.g., "dark_hard", "light_soft")
+  end,
+  everforest = function(variant)
     local background = "dark"
     local style = "medium"
-    
     if variant then
       if variant:match("^light") then
         background = "light"
@@ -144,11 +137,9 @@ local function apply_theme(theme, variant)
         background = "dark"
         style = variant:gsub("^dark_", "")
       else
-        -- If just "hard", "medium", or "soft", use dark background
         style = variant
       end
     end
-    
     require("everforest").setup({
       background = background,
       transparent_background_level = 0,
@@ -164,65 +155,44 @@ local function apply_theme(theme, variant)
       show_eob = true,
       float_style = "bright",
     })
-    
     vim.o.background = background
     vim.cmd.colorscheme("everforest")
-  elseif theme == "nightfox" then
+  end,
+  nightfox = function(variant)
     require("nightfox").setup({
       options = {
         transparent = false,
         terminal_colors = true,
         dim_inactive = false,
-        styles = {
-          comments = "italic",
-          keywords = "bold",
-          types = "italic,bold",
-        },
+        styles = { comments = "italic", keywords = "bold", types = "italic,bold" },
       },
     })
-    -- Variants: nightfox, dayfox, dawnfox, duskfox, nordfox, terafox, carbonfox
     vim.cmd.colorscheme(variant or "nightfox")
-  elseif theme == "zenbones" then
+  end,
+  zenbones = function(variant)
     vim.g.zenbones_compat = 1
     vim.g.zenbones_transparent_background = false
-    -- Variants: zenbones, zenwritten, neobones, tokyobones, seoulbones, 
-    --           forestbones, nordbones, kanagawabones, rosebones
     vim.cmd.colorscheme(variant or "zenbones")
-  elseif theme == "solarized-osaka" then
+  end,
+  ["solarized-osaka"] = function(variant)
     require("solarized-osaka").setup({
       transparent = false,
       terminal_colors = true,
-      styles = {
-        comments = { italic = true },
-        keywords = { italic = true },
-        functions = {},
-        variables = {},
-        sidebars = "dark",
-        floats = "dark",
-      },
-      style = variant or "night", -- storm, night, moon, day
+      styles = { comments = { italic = true }, keywords = { italic = true }, functions = {}, variables = {}, sidebars = "dark", floats = "dark" },
+      style = variant or "night",
     })
     vim.cmd.colorscheme("solarized-osaka")
-  elseif theme == "ayu" then
-    require("ayu").setup({
-      mirage = variant == "mirage",
-      terminal = true,
-      overrides = {},
-    })
-    -- Set background before applying colorscheme
-    if variant == "light" then
-      vim.o.background = "light"
-    else
-      vim.o.background = "dark"
-    end
+  end,
+  ayu = function(variant)
+    require("ayu").setup({ mirage = variant == "mirage", terminal = true, overrides = {} })
+    vim.o.background = variant == "light" and "light" or "dark"
     vim.cmd.colorscheme("ayu")
-  elseif theme == "dracula" then
-    require("dracula").setup({
-      transparent_bg = false,
-      italic_comment = true,
-    })
+  end,
+  dracula = function(_)
+    require("dracula").setup({ transparent_bg = false, italic_comment = true })
     vim.cmd.colorscheme("dracula")
-  elseif theme == "monokai-pro" then
+  end,
+  ["monokai-pro"] = function(variant)
     require("monokai-pro").setup({
       transparent_background = false,
       terminal_colors = true,
@@ -240,94 +210,70 @@ local function apply_theme(theme, variant)
       filter = variant or "pro",
     })
     vim.cmd.colorscheme("monokai-pro")
-  elseif theme == "onedark" then
+  end,
+  onedark = function(variant)
     require("onedarkpro").setup({
-      options = {
-        transparency = false,
-        terminal_colors = true,
-        cursorline = true,
-        highlight_inactive_windows = false,
-      },
-      styles = {
-        comments = "italic",
-        keywords = "bold",
-        functions = "NONE",
-        strings = "NONE",
-        variables = "NONE",
-      },
+      options = { transparency = false, terminal_colors = true, cursorline = true, highlight_inactive_windows = false },
+      styles = { comments = "italic", keywords = "bold", functions = "NONE", strings = "NONE", variables = "NONE" },
     })
     vim.cmd.colorscheme(variant or "onedark")
-  elseif theme == "material" then
+  end,
+  material = function(variant)
     require("material").setup({
-      contrast = {
-        terminal = false,
-        sidebars = false,
-        floating_windows = false,
-        cursor_line = false,
-        non_current_windows = false,
-        filetypes = {},
-      },
-      styles = {
-        comments = { italic = true },
-        strings = {},
-        keywords = { italic = true },
-        functions = {},
-        variables = {},
-        operators = {},
-        types = {},
-      },
-      plugins = {
-        "gitsigns",
-        "telescope",
-        "nvim-cmp",
-        "nvim-web-devicons",
-        "which-key",
-        "mini",
-        "snacks",
-      },
-      disable = {
-        colored_cursor = false,
-        borders = false,
-        background = false,
-        term_colors = false,
-        eob_lines = false,
-      },
+      contrast = { terminal = false, sidebars = false, floating_windows = false, cursor_line = false, non_current_windows = false, filetypes = {} },
+      styles = { comments = { italic = true }, strings = {}, keywords = { italic = true }, functions = {}, variables = {}, operators = {}, types = {} },
+      plugins = { "gitsigns", "telescope", "nvim-cmp", "nvim-web-devicons", "which-key", "mini", "snacks" },
+      disable = { colored_cursor = false, borders = false, background = false, term_colors = false, eob_lines = false },
       lualine_style = "default",
       async_loading = true,
     })
     vim.g.material_style = variant or "darker"
     vim.cmd.colorscheme("material")
-  elseif theme == "melange" then
+  end,
+  melange = function(_)
     vim.cmd.colorscheme("melange")
-  elseif theme == "github" then
+  end,
+  github = function(variant)
     require("github-theme").setup({
       options = {
         transparent = false,
         terminal_colors = true,
         dim_inactive = false,
-        styles = {
-          comments = "italic",
-          keywords = "bold",
-          types = "italic,bold",
-        },
+        styles = { comments = "italic", keywords = "bold", types = "italic,bold" },
       },
     })
     vim.cmd.colorscheme(variant or "github_dark")
+  end,
+}
+
+local function apply_theme(theme, variant)
+  -- Update config if available
+  local config_ok, config = pcall(require, "meowvim.config")
+  if config_ok then
+    config.set("core.theme", theme)
+    if variant then
+      config.set("core.variant", variant)
+    end
+  end
+
+  local applier = theme_appliers[theme]
+  if applier then
+    applier(variant)
   end
 end
 
 function M.select()
   local options = get_base_theme_options()
-  
+
   -- Save current theme for cancel/restore
   local config_ok, config = pcall(require, "meowvim.config")
-  local original_theme = config_ok and config.get("core.theme", "catppuccin") or "catppuccin"
-  
+  local _ = config_ok and config.get("core.theme", "catppuccin") or "catppuccin"
+
   -- Use vim.ui.select for colorscheme selection
   local displays = vim.tbl_map(function(opt)
     return opt.display
   end, options)
-  
+
   vim.ui.select(displays, {
     prompt = "Select theme:",
     format_item = function(item)
@@ -337,48 +283,77 @@ function M.select()
     if choice and idx then
       local selected = options[idx]
       local theme = selected.theme
-      
+
       -- Get smart default variant based on current system appearance
       local variant = M.get_smart_variant(theme)
-      
+
       apply_theme(theme, variant)
-      
+
       -- Persist to config file (as main theme, NOT day/night)
       if config_ok then
         config.set("core.theme", theme)
         config.set("core.variant", variant)
         config.persist()
-        
+
         vim.notify(
           string.format("Theme set to %s (%s) and saved to config.", theme, variant or "default"),
           vim.log.levels.INFO
         )
       else
-        vim.notify(
-          string.format("Theme set to %s (not persisted).", theme),
-          vim.log.levels.WARN
-        )
+        vim.notify(string.format("Theme set to %s (not persisted).", theme), vim.log.levels.WARN)
       end
     end
   end)
 end
 
+-- Helper to check if a variant is light or dark
+local function is_light_variant(_, variant)
+  -- Themes with explicit light variants
+  local light_patterns = {
+    latte = true,
+    day = true,
+    dawn = true,
+    lotus = true,
+    light = true,
+    dayfox = true,
+    dawnfox = true,
+    zenwritten = true, -- light variant of zenbones
+    onelight = true,
+    lighter = true,
+    classic = true, -- monokai-pro classic (lighter)
+    github_light = true,
+  }
+
+  if not variant then
+    return false
+  end
+
+  -- Check if variant name contains light indicators
+  for pattern, _ in pairs(light_patterns) do
+    if variant:match(pattern) then
+      return true
+    end
+  end
+
+  return false
+end
+
 -- Get smart default variant based on system appearance
 function M.get_smart_variant(theme)
   local theme_variants = themes[theme] or {}
-  
+
   if #theme_variants == 0 then
     return nil
   end
-  
+
   -- Try to detect system appearance
   local day_night_ok, day_night = pcall(require, "meowvim.day_night")
   local system_mode = nil
-  
+
   if day_night_ok then
     system_mode = day_night.get_effective_mode()
   end
-  
+
   -- If we can detect system mode, choose appropriate variant
   if system_mode == "day" then
     -- Find light variant
@@ -388,14 +363,14 @@ function M.get_smart_variant(theme)
       end
     end
   end
-  
+
   -- Default to first dark variant or just first variant
   for _, variant in ipairs(theme_variants) do
     if not is_light_variant(theme, variant) then
       return variant
     end
   end
-  
+
   return theme_variants[1]
 end
 
@@ -419,49 +394,17 @@ function M.get_all_theme_options()
   return get_all_theme_options()
 end
 
--- Helper to check if a variant is light or dark
-local function is_light_variant(theme, variant)
-  -- Themes with explicit light variants
-  local light_patterns = {
-    latte = true,
-    day = true,
-    dawn = true,
-    lotus = true,
-    light = true,
-    dayfox = true,
-    dawnfox = true,
-    zenwritten = true, -- light variant of zenbones
-    onelight = true,
-    lighter = true,
-    classic = true, -- monokai-pro classic (lighter)
-    github_light = true,
-  }
-  
-  if not variant then
-    return false
-  end
-  
-  -- Check if variant name contains light indicators
-  for pattern, _ in pairs(light_patterns) do
-    if variant:match(pattern) then
-      return true
-    end
-  end
-  
-  return false
-end
-
 -- Get default light/dark variants for a theme
 function M.get_default_variants(theme)
   local theme_variants = themes[theme] or {}
-  
+
   if #theme_variants == 0 then
     return nil, nil -- No variants
   end
-  
+
   local light_variant = nil
   local dark_variant = nil
-  
+
   for _, variant in ipairs(theme_variants) do
     if is_light_variant(theme, variant) then
       if not light_variant then
@@ -473,11 +416,11 @@ function M.get_default_variants(theme)
       end
     end
   end
-  
+
   -- Defaults if not found
   dark_variant = dark_variant or theme_variants[1]
   light_variant = light_variant or theme_variants[1]
-  
+
   return dark_variant, light_variant
 end
 

--- a/lua/meowvim/config/cache.lua
+++ b/lua/meowvim/config/cache.lua
@@ -47,7 +47,7 @@ end
 function M.save(config)
   local cache_dir = get_cache_dir()
   local cache_file = get_cache_file()
-  
+
   vim.fn.mkdir(cache_dir, "p")
 
   local serialized = "return " .. vim.inspect(config)

--- a/lua/meowvim/config/watcher.lua
+++ b/lua/meowvim/config/watcher.lua
@@ -53,19 +53,23 @@ local function schedule_reload()
   -- Create new uv timer for proper control
   debounce_timer = vim.loop.new_timer()
   if debounce_timer then
-    debounce_timer:start(500, 0, vim.schedule_wrap(function()
-      if debounce_timer and not debounce_timer:is_closing() then
-        debounce_timer:stop()
-        debounce_timer:close()
-      end
-      debounce_timer = nil
-      
-      if is_safe_to_reload() then
-        perform_reload()
-      else
-        reload_pending = true
-      end
-    end))
+    debounce_timer:start(
+      500,
+      0,
+      vim.schedule_wrap(function()
+        if debounce_timer and not debounce_timer:is_closing() then
+          debounce_timer:stop()
+          debounce_timer:close()
+        end
+        debounce_timer = nil
+
+        if is_safe_to_reload() then
+          perform_reload()
+        else
+          reload_pending = true
+        end
+      end)
+    )
   end
 end
 
@@ -124,7 +128,7 @@ function M.stop_all()
     debounce_timer:close()
   end
   debounce_timer = nil
-  
+
   -- Stop all file watchers
   for path, w in pairs(watchers) do
     if w and not w:is_closing() then
@@ -154,7 +158,7 @@ function M.setup()
       end
     end,
   })
-  
+
   -- Clean up watchers on exit
   vim.api.nvim_create_autocmd("VimLeavePre", {
     group = vim.api.nvim_create_augroup("MeowvimConfigWatcherCleanup", { clear = true }),

--- a/lua/meowvim/day_night.lua
+++ b/lua/meowvim/day_night.lua
@@ -17,10 +17,10 @@ local function get_system_appearance()
     if not handle then
       return nil
     end
-    
+
     local result = handle:read("*a")
     handle:close()
-    
+
     -- If "Dark" is returned, system is in dark mode
     -- If empty/error, system is in light mode
     if result and result:match("Dark") then
@@ -29,7 +29,7 @@ local function get_system_appearance()
       return "day"
     end
   end
-  
+
   -- Windows
   if vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 then
     -- Check Windows Registry for theme
@@ -39,10 +39,10 @@ local function get_system_appearance()
     if not handle then
       return nil
     end
-    
+
     local result = handle:read("*a")
     handle:close()
-    
+
     -- AppsUseLightTheme = 0x0 means dark mode
     -- AppsUseLightTheme = 0x1 means light mode
     if result:match("0x0") then
@@ -50,10 +50,10 @@ local function get_system_appearance()
     elseif result:match("0x1") then
       return "day"
     end
-    
+
     return nil
   end
-  
+
   -- Linux - try multiple desktop environments
   if vim.fn.has("unix") == 1 then
     -- Try GNOME (gsettings)
@@ -61,7 +61,7 @@ local function get_system_appearance()
     if handle then
       local result = handle:read("*a")
       handle:close()
-      
+
       if result then
         -- Check if theme name contains "dark" (case-insensitive)
         if result:lower():match("dark") then
@@ -71,13 +71,13 @@ local function get_system_appearance()
         end
       end
     end
-    
+
     -- Try KDE Plasma (kreadconfig5)
     handle = io.popen("kreadconfig5 --group General --key ColorScheme 2>/dev/null")
     if handle then
       local result = handle:read("*a")
       handle:close()
-      
+
       if result then
         if result:lower():match("dark") then
           return "night"
@@ -86,7 +86,7 @@ local function get_system_appearance()
         end
       end
     end
-    
+
     -- Try checking GTK theme directly from config file
     local gtk_config = vim.fn.expand("~/.config/gtk-3.0/settings.ini")
     if vim.fn.filereadable(gtk_config) == 1 then
@@ -94,7 +94,7 @@ local function get_system_appearance()
       if file then
         local content = file:read("*a")
         file:close()
-        
+
         local theme = content:match("gtk%-theme%-name%s*=%s*(.-)%s*\n")
         if theme then
           if theme:lower():match("dark") then
@@ -105,13 +105,15 @@ local function get_system_appearance()
         end
       end
     end
-    
+
     -- Try freedesktop color-scheme standard (newer method)
-    handle = io.popen("dbus-send --session --print-reply=literal --dest=org.freedesktop.portal.Desktop /org/freedesktop/portal/desktop org.freedesktop.portal.Settings.Read string:'org.freedesktop.appearance' string:'color-scheme' 2>/dev/null")
+    handle = io.popen(
+      "dbus-send --session --print-reply=literal --dest=org.freedesktop.portal.Desktop /org/freedesktop/portal/desktop org.freedesktop.portal.Settings.Read string:'org.freedesktop.appearance' string:'color-scheme' 2>/dev/null"
+    )
     if handle then
       local result = handle:read("*a")
       handle:close()
-      
+
       -- 0 = no preference, 1 = prefer dark, 2 = prefer light
       if result:match("uint32 1") then
         return "night"
@@ -119,10 +121,10 @@ local function get_system_appearance()
         return "day"
       end
     end
-    
+
     return nil
   end
-  
+
   return nil
 end
 
@@ -132,13 +134,13 @@ local function get_theme_for_mode(mode)
   if not config_ok then
     return nil, nil
   end
-  
+
   if mode == "day" then
     return config.get("core.day_theme", "catppuccin"), config.get("core.day_variant", "latte")
   elseif mode == "night" then
     return config.get("core.night_theme", "catppuccin"), config.get("core.night_variant", "mocha")
   end
-  
+
   return nil, nil
 end
 
@@ -148,14 +150,14 @@ local function apply_mode_theme(mode)
   if not theme then
     return false
   end
-  
+
   -- Use colorscheme switcher to apply theme
   local switcher_ok, switcher = pcall(require, "meowvim.colorscheme_switcher")
   if switcher_ok and switcher.apply_theme then
     switcher.apply_theme(theme, variant)
     return true
   end
-  
+
   return false
 end
 
@@ -165,9 +167,9 @@ function M.get_effective_mode()
   if not config_ok then
     return "night"
   end
-  
+
   local mode = config.get("core.day_night_mode", "manual")
-  
+
   if mode == "auto" then
     return get_system_appearance() or "night"
   else
@@ -189,34 +191,28 @@ end
 function M.set_mode(mode)
   local valid_modes = { manual = true, auto = true }
   if not valid_modes[mode] then
-    vim.notify(
-      string.format("Invalid day/night mode: %s. Use: manual, auto", mode),
-      vim.log.levels.ERROR
-    )
+    vim.notify(string.format("Invalid day/night mode: %s. Use: manual, auto", mode), vim.log.levels.ERROR)
     return false
   end
-  
+
   local config_ok, config = pcall(require, "meowvim.config")
   if config_ok then
     config.set("core.day_night_mode", mode)
   end
-  
+
   -- Stop watching if we're not in auto mode
   if mode ~= "auto" then
     M.stop_watching()
   end
-  
+
   -- Apply theme immediately if in auto mode
   if mode == "auto" then
     M.apply_current_mode()
     M.start_watching()
   end
-  
-  vim.notify(
-    string.format("Day/night mode set to: %s", mode),
-    vim.log.levels.INFO
-  )
-  
+
+  vim.notify(string.format("Day/night mode set to: %s", mode), vim.log.levels.INFO)
+
   return true
 end
 
@@ -227,14 +223,14 @@ function M.toggle()
     vim.notify("Config not available", vim.log.levels.ERROR)
     return
   end
-  
+
   -- Switch to manual mode immediately
   local current_mode = config.get("core.day_night_mode", "manual")
   if current_mode ~= "manual" then
     config.set("core.day_night_mode", "manual")
     M.stop_watching()
   end
-  
+
   -- Get current theme to determine if we're on day or night
   local current_theme = config.get("core.theme", "catppuccin")
   local current_variant = config.get("core.variant", "mocha")
@@ -242,11 +238,11 @@ function M.toggle()
   local day_variant = config.get("core.day_variant", "latte")
   local night_theme = config.get("core.night_theme", "catppuccin")
   local night_variant = config.get("core.night_variant", "mocha")
-  
+
   -- Check if currently on day or night theme
   local is_day = (current_theme == day_theme and current_variant == day_variant)
   local is_night = (current_theme == night_theme and current_variant == night_variant)
-  
+
   if is_day then
     -- Switch to night
     apply_mode_theme("night")
@@ -268,20 +264,20 @@ local function set_theme_for_time(time_of_day, theme, variant)
   if not config_ok then
     return
   end
-  
+
   local mode = config.get("core.day_night_mode", "manual")
-  
+
   local current_theme = config.get("core.theme", "catppuccin")
   local current_variant = config.get("core.variant", "mocha")
   local old_theme = config.get("core." .. time_of_day .. "_theme", "catppuccin")
   local old_variant = config.get("core." .. time_of_day .. "_variant", time_of_day == "day" and "latte" or "mocha")
-  
+
   config.set("core." .. time_of_day .. "_theme", theme)
   if variant then
     config.set("core." .. time_of_day .. "_variant", variant)
   end
   config.persist()
-  
+
   if mode == "auto" then
     local current_mode = M.get_effective_mode()
     if current_mode == time_of_day then
@@ -312,55 +308,50 @@ function M.start_watching()
   elseif vim.fn.has("unix") == 1 then
     platform = "Linux"
   end
-  
+
   if platform == "unknown" then
-    vim.notify(
-      "System theme sync not supported on this platform",
-      vim.log.levels.WARN
-    )
+    vim.notify("System theme sync not supported on this platform", vim.log.levels.WARN)
     return false
   end
-  
+
   if is_watching then
     return true
   end
-  
+
   local last_appearance = get_system_appearance()
-  
+
   -- Poll every 2 seconds for system appearance changes
   timer = vim.loop.new_timer()
   if not timer then
     return false
   end
-  
-  timer:start(2000, 2000, vim.schedule_wrap(function()
-    local current_appearance = get_system_appearance()
-    
-    if current_appearance and current_appearance ~= last_appearance then
-      last_appearance = current_appearance
-      
-      -- Check if still in auto mode
-      local config_ok, config = pcall(require, "meowvim.config")
-      local mode = config_ok and config.get("core.day_night_mode", "manual") or "manual"
-      
-      if mode == "auto" then
-        apply_mode_theme(current_appearance)
-        vim.notify(
-          string.format("System theme changed to %s mode", current_appearance),
-          vim.log.levels.INFO
-        )
-      else
-        -- Mode changed, stop watching
-        M.stop_watching()
+
+  timer:start(
+    2000,
+    2000,
+    vim.schedule_wrap(function()
+      local current_appearance = get_system_appearance()
+
+      if current_appearance and current_appearance ~= last_appearance then
+        last_appearance = current_appearance
+
+        -- Check if still in auto mode
+        local config_ok, config = pcall(require, "meowvim.config")
+        local mode = config_ok and config.get("core.day_night_mode", "manual") or "manual"
+
+        if mode == "auto" then
+          apply_mode_theme(current_appearance)
+          vim.notify(string.format("System theme changed to %s mode", current_appearance), vim.log.levels.INFO)
+        else
+          -- Mode changed, stop watching
+          M.stop_watching()
+        end
       end
-    end
-  end))
-  
-  is_watching = true
-  vim.notify(
-    string.format("Started watching system theme (%s)", platform),
-    vim.log.levels.INFO
+    end)
   )
+
+  is_watching = true
+  vim.notify(string.format("Started watching system theme (%s)", platform), vim.log.levels.INFO)
   return true
 end
 
@@ -379,17 +370,17 @@ end
 function M.select_mode()
   local config_ok, config = pcall(require, "meowvim.config")
   local current_mode = config_ok and config.get("core.day_night_mode", "manual") or "manual"
-  
+
   local modes = {
     { mode = "manual", desc = "toggle with <leader>oK" },
     { mode = "auto", desc = "sync with OS" },
   }
-  
+
   local displays = vim.tbl_map(function(item)
     local indicator = item.mode == current_mode and "● " or "  "
     return string.format("%s%s - %s", indicator, item.mode:gsub("^%l", string.upper), item.desc)
   end, modes)
-  
+
   vim.ui.select(displays, {
     prompt = string.format("Mode (current: %s)", current_mode),
     format_item = function(item)
@@ -404,24 +395,24 @@ end
 
 -- Interactive day/night theme pair setup
 function M.setup_themes()
-  local switcher_ok, switcher = pcall(require, "meowvim.colorscheme_switcher")
+  local switcher_ok, _ = pcall(require, "meowvim.colorscheme_switcher")
   if not switcher_ok then
     vim.notify("Colorscheme switcher not available", vim.log.levels.ERROR)
     return
   end
-  
+
   local config_ok, config = pcall(require, "meowvim.config")
   if not config_ok then
     vim.notify("Config not available", vim.log.levels.ERROR)
     return
   end
-  
+
   -- Get current day/night themes
   local current_day_theme = config.get("core.day_theme", "catppuccin")
   local current_day_variant = config.get("core.day_variant", "latte")
   local current_night_theme = config.get("core.night_theme", "catppuccin")
   local current_night_variant = config.get("core.night_variant", "mocha")
-  
+
   -- Show menu
   local options = {
     string.format("Day theme: %s (%s)", current_day_theme, current_day_variant or "default"),
@@ -430,7 +421,7 @@ function M.setup_themes()
     "Set current theme as NIGHT theme",
     "Use preset pair",
   }
-  
+
   vim.ui.select(options, {
     prompt = "Day/Night theme setup:",
     format_item = function(item)
@@ -440,7 +431,7 @@ function M.setup_themes()
     if not choice then
       return
     end
-    
+
     if idx == 1 then
       -- Select day theme
       M._select_theme_for_slot("day")
@@ -476,14 +467,14 @@ function M._select_theme_for_slot(slot)
     vim.notify("Colorscheme switcher not available", vim.log.levels.ERROR)
     return
   end
-  
+
   -- Get all theme options with variants
   local options = switcher.get_all_theme_options()
-  
+
   local displays = vim.tbl_map(function(opt)
     return opt.display
   end, options)
-  
+
   vim.ui.select(displays, {
     prompt = string.format("Select %s theme:", slot:upper()),
     format_item = function(item)
@@ -492,7 +483,7 @@ function M._select_theme_for_slot(slot)
   }, function(choice, idx)
     if choice and idx then
       local selected = options[idx]
-      
+
       if slot == "day" then
         M.set_day_theme(selected.theme, selected.variant)
       else
@@ -508,13 +499,13 @@ function M.setup()
   vim.defer_fn(function()
     local config_ok, config = pcall(require, "meowvim.config")
     local mode = config_ok and config.get("core.day_night_mode", "manual") or "manual"
-    
+
     if mode == "auto" then
       M.apply_current_mode()
       M.start_watching()
     end
   end, 100)
-  
+
   -- Cleanup on exit
   vim.api.nvim_create_autocmd("VimLeavePre", {
     group = vim.api.nvim_create_augroup("meowvim-day-night-cleanup", { clear = true }),
@@ -522,7 +513,7 @@ function M.setup()
       M.stop_watching()
     end,
   })
-  
+
   -- Re-detect project on directory change
   vim.api.nvim_create_autocmd("DirChanged", {
     group = vim.api.nvim_create_augroup("meowvim-day-night-dirchange", { clear = true }),
@@ -533,7 +524,7 @@ function M.setup()
       end
     end,
   })
-  
+
   -- Register commands
   vim.api.nvim_create_user_command("DayNightMode", function(opts)
     if opts.args == "" then
@@ -548,15 +539,15 @@ function M.setup()
     end,
     desc = "Set or select day/night mode",
   })
-  
+
   vim.api.nvim_create_user_command("DayNightToggle", function()
     M.toggle()
   end, { desc = "Toggle between day and night modes" })
-  
+
   vim.api.nvim_create_user_command("DayNightSetup", function()
     M.setup_themes()
   end, { desc = "Setup day/night theme pairs interactively" })
-  
+
   -- Command to set current theme as day or night theme
   vim.api.nvim_create_user_command("DayNightSetTheme", function(opts)
     local mode = opts.args
@@ -564,29 +555,23 @@ function M.setup()
       vim.notify("Usage: DayNightSetTheme day|night", vim.log.levels.ERROR)
       return
     end
-    
+
     local config_ok, config = pcall(require, "meowvim.config")
     if not config_ok then
       vim.notify("Failed to load config", vim.log.levels.ERROR)
       return
     end
-    
+
     -- Get current theme and variant
     local theme = config.get("core.theme", "catppuccin")
     local variant = config.get("core.variant", "mocha")
-    
+
     if mode == "day" then
       M.set_day_theme(theme, variant)
-      vim.notify(
-        string.format("Day theme set to: %s (%s)", theme, variant or "default"),
-        vim.log.levels.INFO
-      )
+      vim.notify(string.format("Day theme set to: %s (%s)", theme, variant or "default"), vim.log.levels.INFO)
     else
       M.set_night_theme(theme, variant)
-      vim.notify(
-        string.format("Night theme set to: %s (%s)", theme, variant or "default"),
-        vim.log.levels.INFO
-      )
+      vim.notify(string.format("Night theme set to: %s (%s)", theme, variant or "default"), vim.log.levels.INFO)
     end
   end, {
     nargs = 1,

--- a/lua/meowvim/day_night_presets.lua
+++ b/lua/meowvim/day_night_presets.lua
@@ -38,7 +38,7 @@ M.presets = {
     day = { theme = "everforest", variant = "light_soft" },
     night = { theme = "everforest", variant = "dark_medium" },
   },
-  
+
   -- Modern & Popular
   catppuccin = {
     name = "Catppuccin",
@@ -47,7 +47,7 @@ M.presets = {
     day = { theme = "catppuccin", variant = "latte" },
     night = { theme = "catppuccin", variant = "mocha" },
   },
-  
+
   tokyonight = {
     name = "Tokyo Night",
     description = "Clean, professional, excellent LSP/Treesitter support",
@@ -55,7 +55,7 @@ M.presets = {
     day = { theme = "tokyonight", variant = "day" },
     night = { theme = "tokyonight", variant = "storm" },
   },
-  
+
   -- Artistic & Elegant
   kanagawa = {
     name = "Kanagawa",
@@ -64,7 +64,7 @@ M.presets = {
     day = { theme = "kanagawa", variant = "lotus" },
     night = { theme = "kanagawa", variant = "wave" },
   },
-  
+
   rosepine = {
     name = "Rose Pine",
     description = "Minimal palette, mountain sunset vibes, meditative",
@@ -72,7 +72,7 @@ M.presets = {
     day = { theme = "rose-pine", variant = "dawn" },
     night = { theme = "rose-pine", variant = "main" },
   },
-  
+
   -- High Contrast & Technical
   nightfox = {
     name = "Nightfox",
@@ -81,7 +81,7 @@ M.presets = {
     day = { theme = "nightfox", variant = "dayfox" },
     night = { theme = "nightfox", variant = "nightfox" },
   },
-  
+
   -- Mathematical Precision
   solarized = {
     name = "Solarized Osaka",
@@ -90,7 +90,7 @@ M.presets = {
     day = { theme = "solarized-osaka", variant = "day" },
     night = { theme = "solarized-osaka", variant = "night" },
   },
-  
+
   -- Pure Minimalism
   zenbones = {
     name = "Zenbones",
@@ -99,7 +99,7 @@ M.presets = {
     day = { theme = "zenbones", variant = "zenwritten" },
     night = { theme = "zenbones", variant = "zenbones" },
   },
-  
+
   -- Clean Design Studio
   ayu = {
     name = "Ayu",
@@ -108,7 +108,7 @@ M.presets = {
     day = { theme = "ayu", variant = "light" },
     night = { theme = "ayu", variant = "dark" },
   },
-  
+
   -- Warm Retro (only dark, but listed for completeness)
   gruvbox = {
     name = "Gruvbox",
@@ -117,7 +117,7 @@ M.presets = {
     day = { theme = "gruvbox", variant = "soft" },
     night = { theme = "gruvbox", variant = "medium" },
   },
-  
+
   -- Classic Dark (dark only, paired with ayu light)
   dracula = {
     name = "Dracula",
@@ -126,7 +126,7 @@ M.presets = {
     day = { theme = "ayu", variant = "light" },
     night = { theme = "dracula", variant = nil },
   },
-  
+
   -- Professional Studio
   monokai = {
     name = "Monokai Pro",
@@ -135,7 +135,7 @@ M.presets = {
     day = { theme = "monokai-pro", variant = "classic" },
     night = { theme = "monokai-pro", variant = "pro" },
   },
-  
+
   -- Balanced & Familiar
   onedark = {
     name = "One Dark",
@@ -144,7 +144,7 @@ M.presets = {
     day = { theme = "onedark", variant = "onelight" },
     night = { theme = "onedark", variant = "onedark" },
   },
-  
+
   -- Material Design
   material = {
     name = "Material",
@@ -153,7 +153,7 @@ M.presets = {
     day = { theme = "material", variant = "lighter" },
     night = { theme = "material", variant = "darker" },
   },
-  
+
   -- Warm Balanced (dark only, paired with everforest)
   melange = {
     name = "Melange",
@@ -162,7 +162,7 @@ M.presets = {
     day = { theme = "everforest", variant = "light_soft" },
     night = { theme = "melange", variant = nil },
   },
-  
+
   -- GitHub Official
   github = {
     name = "GitHub",
@@ -178,12 +178,12 @@ function M.get_preset(preset_name)
   if not preset_name then
     return nil
   end
-  
+
   local preset = M.presets[preset_name]
   if not preset then
     return nil
   end
-  
+
   return {
     day_theme = preset.day.theme,
     day_variant = preset.day.variant,
@@ -196,34 +196,31 @@ end
 function M.apply_preset(preset_name)
   local preset = M.presets[preset_name]
   if not preset then
-    vim.notify(
-      string.format("Unknown preset: %s", preset_name),
-      vim.log.levels.ERROR
-    )
+    vim.notify(string.format("Unknown preset: %s", preset_name), vim.log.levels.ERROR)
     return false
   end
-  
+
   local day_night = require("meowvim.day_night")
   local config_ok, config = pcall(require, "meowvim.config")
-  
+
   -- Set day theme
   day_night.set_day_theme(preset.day.theme, preset.day.variant)
-  
+
   -- Set night theme
   day_night.set_night_theme(preset.night.theme, preset.night.variant)
-  
+
   -- Save last preset for detection
   if config_ok then
     config.set("core.last_preset", preset_name)
     config.persist()
   end
-  
+
   -- Apply current mode's theme immediately
   local current_mode = day_night.get_effective_mode()
   if current_mode then
     day_night.apply_current_mode()
   end
-  
+
   vim.notify(
     string.format(
       "Applied preset: %s\nDay: %s (%s)\nNight: %s (%s)",
@@ -235,7 +232,7 @@ function M.apply_preset(preset_name)
     ),
     vim.log.levels.INFO
   )
-  
+
   return true
 end
 
@@ -244,31 +241,26 @@ function M.select_preset()
   -- Get current preset
   local config_ok, config = pcall(require, "meowvim.config")
   local current_preset = config_ok and config.get("core.last_preset", nil) or nil
-  
+
   local preset_names = {}
   local presets_list = {}
-  
+
   for key, preset in pairs(M.presets) do
     table.insert(presets_list, { key = key, preset = preset })
   end
-  
+
   -- Sort by name
   table.sort(presets_list, function(a, b)
     return a.preset.name < b.preset.name
   end)
-  
+
   -- Create display strings
   for _, item in ipairs(presets_list) do
     local indicator = item.key == current_preset and "● " or "  "
-    local display = string.format(
-      "%s%s - %s",
-      indicator,
-      item.preset.name,
-      item.preset.mood
-    )
+    local display = string.format("%s%s - %s", indicator, item.preset.name, item.preset.mood)
     table.insert(preset_names, { key = item.key, display = display })
   end
-  
+
   vim.ui.select(preset_names, {
     prompt = string.format("Preset (current: %s)", current_preset or "none"),
     format_item = function(item)

--- a/lua/meowvim/health.lua
+++ b/lua/meowvim/health.lua
@@ -16,23 +16,37 @@ local info = health.info or health.report_info
 -- Check Neovim version
 local function check_nvim_version()
   start("Neovim Version")
-  
+
   local required_version = "0.10.0"
   local current_version = vim.version()
-  
+
   if current_version.major == 0 and current_version.minor >= 10 then
-    ok(string.format("Neovim %d.%d.%d (>= %s)", 
-      current_version.major, current_version.minor, current_version.patch, required_version))
+    ok(
+      string.format(
+        "Neovim %d.%d.%d (>= %s)",
+        current_version.major,
+        current_version.minor,
+        current_version.patch,
+        required_version
+      )
+    )
   else
-    error(string.format("Neovim %d.%d.%d is too old. Please upgrade to >= %s",
-      current_version.major, current_version.minor, current_version.patch, required_version))
+    error(
+      string.format(
+        "Neovim %d.%d.%d is too old. Please upgrade to >= %s",
+        current_version.major,
+        current_version.minor,
+        current_version.patch,
+        required_version
+      )
+    )
   end
 end
 
 -- Check configuration system
 local function check_config()
   start("Configuration System")
-  
+
   -- Check if config module loads
   local config_ok, config = pcall(require, "meowvim.config")
   if not config_ok then
@@ -40,7 +54,7 @@ local function check_config()
     return
   end
   ok("Config module loaded successfully")
-  
+
   -- Check if user config exists
   local config_path = config.get_config_path()
   if vim.fn.filereadable(config_path) == 1 then
@@ -49,7 +63,7 @@ local function check_config()
     warn("User config file not found: " .. config_path)
     info("Create one by running :MeowvimConfig or copying from defaults")
   end
-  
+
   -- Validate config
   local valid, errors = config.validate()
   if valid then
@@ -60,16 +74,16 @@ local function check_config()
       info("  " .. field .. ": " .. err)
     end
   end
-  
+
   -- Check critical config values
   local theme = config.get("core.theme")
   if theme then
     info("Theme: " .. theme)
   end
-  
+
   local copilot = config.get("core.enable_copilot", false)
   info("Copilot: " .. (copilot and "enabled" or "disabled"))
-  
+
   -- Check projects configuration
   local projects_path = config.get_projects_path()
   if vim.fn.filereadable(projects_path) == 1 then
@@ -100,7 +114,7 @@ end
 -- Check external dependencies
 local function check_external_deps()
   start("External Dependencies")
-  
+
   -- Check git
   if vim.fn.executable("git") == 1 then
     local git_version = vim.fn.system("git --version"):gsub("\n", "")
@@ -108,7 +122,7 @@ local function check_external_deps()
   else
     error("git is not installed or not in PATH")
   end
-  
+
   -- Check ripgrep (for telescope)
   if vim.fn.executable("rg") == 1 then
     local rg_version = vim.fn.system("rg --version"):match("ripgrep ([^\n]+)")
@@ -117,7 +131,7 @@ local function check_external_deps()
     warn("ripgrep not found - Telescope search will be slower")
     info("Install with: brew install ripgrep (macOS) or apt install ripgrep (Linux)")
   end
-  
+
   -- Check fd (for telescope)
   if vim.fn.executable("fd") == 1 then
     local fd_version = vim.fn.system("fd --version"):match("fd ([^\n]+)")
@@ -126,7 +140,7 @@ local function check_external_deps()
     warn("fd not found - Telescope file finding will be slower")
     info("Install with: brew install fd (macOS) or apt install fd-find (Linux)")
   end
-  
+
   -- Check lazygit
   if vim.fn.executable("lazygit") == 1 then
     local lg_version = vim.fn.system("lazygit --version"):match("version=([^,]+)")
@@ -135,7 +149,7 @@ local function check_external_deps()
     info("lazygit not found - :LazyGit command will not work")
     info("Install from: https://github.com/jesseduffield/lazygit")
   end
-  
+
   -- Check node (for Copilot)
   if vim.fn.executable("node") == 1 then
     local node_version = vim.fn.system("node --version"):gsub("\n", "")
@@ -154,19 +168,19 @@ end
 -- Check LSP servers
 local function check_lsp()
   start("LSP Configuration")
-  
+
   local lspconfig_ok, _ = pcall(require, "lspconfig")
   if not lspconfig_ok then
     error("nvim-lspconfig not loaded")
     return
   end
   ok("nvim-lspconfig loaded")
-  
+
   -- Check Mason
-  local mason_ok, mason = pcall(require, "mason")
+  local mason_ok, _ = pcall(require, "mason")
   if mason_ok then
     ok("Mason package manager loaded")
-    
+
     local registry_ok, registry = pcall(require, "mason-registry")
     if registry_ok then
       local installed = registry.get_installed_packages()
@@ -188,17 +202,17 @@ end
 -- Check plugin manager
 local function check_plugins()
   start("Plugin Manager")
-  
+
   local lazy_ok, lazy = pcall(require, "lazy")
   if not lazy_ok then
     error("lazy.nvim not loaded")
     return
   end
   ok("lazy.nvim loaded")
-  
+
   local stats = lazy.stats()
   ok(string.format("%d plugins loaded in %.2fms", stats.loaded, stats.startuptime))
-  
+
   if stats.count > stats.loaded then
     info(string.format("%d plugins not yet loaded (lazy-loaded)", stats.count - stats.loaded))
   end
@@ -207,14 +221,14 @@ end
 -- Check treesitter
 local function check_treesitter()
   start("Tree-sitter")
-  
-  local ts_ok, ts_configs = pcall(require, "nvim-treesitter.configs")
+
+  local ts_ok, _ = pcall(require, "nvim-treesitter.configs")
   if not ts_ok then
     error("nvim-treesitter not loaded")
     return
   end
   ok("nvim-treesitter loaded")
-  
+
   local parser_ok, parser = pcall(require, "nvim-treesitter.parsers")
   if parser_ok then
     local installed = parser.get_parser_configs()
@@ -234,7 +248,7 @@ end
 -- Check critical files and directories
 local function check_filesystem()
   start("Filesystem")
-  
+
   -- Check data directory
   local data_dir = vim.fn.stdpath("data")
   if vim.fn.isdirectory(data_dir) == 1 then
@@ -242,7 +256,7 @@ local function check_filesystem()
   else
     error("Data directory missing: " .. data_dir)
   end
-  
+
   -- Check config directory
   local config_dir = vim.fn.stdpath("config")
   if vim.fn.isdirectory(config_dir) == 1 then
@@ -250,7 +264,7 @@ local function check_filesystem()
   else
     error("Config directory missing: " .. config_dir)
   end
-  
+
   -- Check cache directory
   local cache_dir = vim.fn.stdpath("cache")
   if vim.fn.isdirectory(cache_dir) == 1 then
@@ -258,7 +272,7 @@ local function check_filesystem()
   else
     warn("Cache directory missing: " .. cache_dir)
   end
-  
+
   -- Check if running in container
   if vim.env.CI or vim.env.DOCKER or vim.fn.filereadable("/.dockerenv") == 1 then
     info("Running in CI/container environment")

--- a/lua/meowvim/keymap_checker.lua
+++ b/lua/meowvim/keymap_checker.lua
@@ -10,7 +10,7 @@ local M = {}
 local function get_keymaps(mode)
   local keymaps = vim.api.nvim_get_keymap(mode)
   local buf_keymaps = vim.api.nvim_buf_get_keymap(0, mode)
-  
+
   -- Merge global and buffer-local keymaps
   local all_keymaps = {}
   for _, km in ipairs(keymaps) do
@@ -19,7 +19,7 @@ local function get_keymaps(mode)
   for _, km in ipairs(buf_keymaps) do
     table.insert(all_keymaps, vim.tbl_extend("force", km, { scope = "buffer" }))
   end
-  
+
   return all_keymaps
 end
 
@@ -27,11 +27,11 @@ end
 local function find_conflicts()
   local modes = { "n", "i", "v", "x", "s", "o", "t", "c" }
   local conflicts = {}
-  
+
   for _, mode in ipairs(modes) do
     local keymaps = get_keymaps(mode)
     local seen = {}
-    
+
     for _, km in ipairs(keymaps) do
       local lhs = km.lhs or ""
       if seen[lhs] then
@@ -45,51 +45,56 @@ local function find_conflicts()
       end
     end
   end
-  
+
   return conflicts
 end
 
 -- Format keymap info
 local function format_keymap(km)
   local parts = {}
-  
+
   if km.desc and km.desc ~= "" then
     table.insert(parts, string.format('"%s"', km.desc))
   end
-  
+
   if km.callback then
     table.insert(parts, "<Lua function>")
   elseif km.rhs then
-    table.insert(parts, string.format('-> %s', km.rhs))
+    table.insert(parts, string.format("-> %s", km.rhs))
   end
-  
+
   if km.buffer and km.buffer ~= 0 then
-    table.insert(parts, string.format('[buf:%d]', km.buffer))
+    table.insert(parts, string.format("[buf:%d]", km.buffer))
   end
-  
+
   if km.scope then
-    table.insert(parts, string.format('[%s]', km.scope))
+    table.insert(parts, string.format("[%s]", km.scope))
   end
-  
+
   return #parts > 0 and table.concat(parts, " ") or "<no info>"
+end
+
+-- Return conflicts as a plain list (headless-safe)
+function M.get_conflicts()
+  return find_conflicts()
 end
 
 -- Display conflicts in a buffer
 function M.show_conflicts()
   local conflicts = find_conflicts()
-  
+
   if #conflicts == 0 then
     vim.notify("No keymap conflicts detected!", vim.log.levels.INFO)
     return
   end
-  
+
   -- Create new buffer
   local buf = vim.api.nvim_create_buf(false, true)
   vim.bo[buf].buftype = "nofile"
   vim.bo[buf].bufhidden = "wipe"
   vim.bo[buf].swapfile = false
   vim.api.nvim_buf_set_name(buf, "Keymap Conflicts")
-  
+
   -- Build content
   local lines = {
     "# Keymap Conflicts Detected",
@@ -97,7 +102,7 @@ function M.show_conflicts()
     string.format("Found %d potential conflicts:", #conflicts),
     "",
   }
-  
+
   for i, conflict in ipairs(conflicts) do
     table.insert(lines, string.format("## Conflict %d: [%s] %s", i, conflict.mode, conflict.lhs))
     for j, km in ipairs(conflict.maps) do
@@ -105,12 +110,12 @@ function M.show_conflicts()
     end
     table.insert(lines, "")
   end
-  
+
   -- Set content
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
   vim.bo[buf].modifiable = false
   vim.bo[buf].filetype = "markdown"
-  
+
   -- Open in split
   vim.cmd("vsplit")
   vim.api.nvim_win_set_buf(0, buf)
@@ -121,24 +126,24 @@ end
 function M.list_keymaps(mode)
   mode = mode or "n"
   local keymaps = get_keymaps(mode)
-  
+
   if #keymaps == 0 then
     vim.notify(string.format("No keymaps found for mode '%s'", mode), vim.log.levels.INFO)
     return
   end
-  
+
   -- Sort by lhs
   table.sort(keymaps, function(a, b)
     return (a.lhs or "") < (b.lhs or "")
   end)
-  
+
   -- Create buffer
   local buf = vim.api.nvim_create_buf(false, true)
   vim.bo[buf].buftype = "nofile"
   vim.bo[buf].bufhidden = "wipe"
   vim.bo[buf].swapfile = false
   vim.api.nvim_buf_set_name(buf, string.format("Keymaps [%s]", mode))
-  
+
   -- Build content
   local lines = {
     string.format("# Keymaps for mode: %s", mode),
@@ -146,18 +151,18 @@ function M.list_keymaps(mode)
     string.format("Total: %d keymaps", #keymaps),
     "",
   }
-  
+
   for _, km in ipairs(keymaps) do
     local lhs = km.lhs or "<unknown>"
     local info = format_keymap(km)
     table.insert(lines, string.format("%-20s %s", lhs, info))
   end
-  
+
   -- Set content
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
   vim.bo[buf].modifiable = false
   vim.bo[buf].filetype = "markdown"
-  
+
   -- Open in split
   vim.cmd("vsplit")
   vim.api.nvim_win_set_buf(0, buf)

--- a/lua/meowvim/profiler.lua
+++ b/lua/meowvim/profiler.lua
@@ -10,21 +10,21 @@ local M = {}
 function M.profile_function(fn, iterations)
   iterations = iterations or 100
   local times = {}
-  
+
   for i = 1, iterations do
     local start = vim.loop.hrtime()
     fn()
     local elapsed = (vim.loop.hrtime() - start) / 1000000 -- Convert to ms
     table.insert(times, elapsed)
   end
-  
+
   -- Calculate statistics
   table.sort(times)
   local total = 0
   for _, t in ipairs(times) do
     total = total + t
   end
-  
+
   local stats = {
     min = times[1],
     max = times[#times],
@@ -33,7 +33,7 @@ function M.profile_function(fn, iterations)
     p95 = times[math.floor(#times * 0.95)],
     p99 = times[math.floor(#times * 0.99)],
   }
-  
+
   return stats
 end
 
@@ -58,10 +58,10 @@ function M.show_plugin_times()
     vim.notify("lazy.nvim not loaded", vim.log.levels.ERROR)
     return
   end
-  
+
   local stats = lazy.stats()
   local plugins = lazy.plugins()
-  
+
   -- Collect load times
   local plugin_times = {}
   for _, plugin in ipairs(plugins) do
@@ -73,19 +73,19 @@ function M.show_plugin_times()
       })
     end
   end
-  
+
   -- Sort by time
   table.sort(plugin_times, function(a, b)
     return a.time > b.time
   end)
-  
+
   -- Create buffer
   local buf = vim.api.nvim_create_buf(false, true)
   vim.bo[buf].buftype = "nofile"
   vim.bo[buf].bufhidden = "wipe"
   vim.bo[buf].swapfile = false
   vim.api.nvim_buf_set_name(buf, "Plugin Load Times")
-  
+
   -- Build content
   local lines = {
     "# Plugin Load Times",
@@ -97,17 +97,17 @@ function M.show_plugin_times()
     "## Top 20 Slowest Plugins",
     "",
   }
-  
+
   for i = 1, math.min(20, #plugin_times) do
     local p = plugin_times[i]
     table.insert(lines, string.format("%2d. %-40s %6.2fms", i, p.name, p.time))
   end
-  
+
   -- Set content
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
   vim.bo[buf].modifiable = false
   vim.bo[buf].filetype = "markdown"
-  
+
   -- Open in split
   vim.cmd("vsplit")
   vim.api.nvim_win_set_buf(0, buf)
@@ -119,7 +119,7 @@ function M.measure_buffer_render()
   local start = vim.loop.hrtime()
   vim.cmd("redraw!")
   local elapsed = (vim.loop.hrtime() - start) / 1000000
-  
+
   vim.notify(string.format("Buffer render time: %.2fms", elapsed), vim.log.levels.INFO)
   return elapsed
 end

--- a/lua/meowvim/startup_tracker.lua
+++ b/lua/meowvim/startup_tracker.lua
@@ -14,7 +14,7 @@ function M.record()
   if not lazy_ok then
     return
   end
-  
+
   local stats = lazy.stats()
   local metric = {
     timestamp = os.time(),
@@ -22,16 +22,16 @@ function M.record()
     plugin_count = stats.count,
     loaded_count = stats.loaded,
   }
-  
+
   -- Load existing metrics
   local metrics = M.load_metrics()
   table.insert(metrics, metric)
-  
+
   -- Keep only last 100 entries
   if #metrics > 100 then
     metrics = vim.list_slice(metrics, #metrics - 99, #metrics)
   end
-  
+
   -- Save metrics
   local ok, json = pcall(vim.json.encode, metrics)
   if ok then
@@ -49,52 +49,52 @@ function M.load_metrics()
   if not file then
     return {}
   end
-  
+
   local content = file:read("*all")
   file:close()
-  
+
   local ok, metrics = pcall(vim.json.decode, content)
   if not ok or type(metrics) ~= "table" then
     return {}
   end
-  
+
   return metrics
 end
 
 -- Show startup time trends
 function M.show_trends()
   local metrics = M.load_metrics()
-  
+
   if #metrics == 0 then
     vim.notify("No startup metrics recorded yet", vim.log.levels.INFO)
     return
   end
-  
+
   -- Calculate statistics
   local times = {}
   for _, m in ipairs(metrics) do
     table.insert(times, m.startuptime)
   end
-  
+
   table.sort(times)
   local total = 0
   for _, t in ipairs(times) do
     total = total + t
   end
-  
+
   local avg = total / #times
   local min = times[1]
   local max = times[#times]
   local median = times[math.floor(#times / 2)]
   local latest = metrics[#metrics].startuptime
-  
+
   -- Create buffer
   local buf = vim.api.nvim_create_buf(false, true)
   vim.bo[buf].buftype = "nofile"
   vim.bo[buf].bufhidden = "wipe"
   vim.bo[buf].swapfile = false
   vim.api.nvim_buf_set_name(buf, "Startup Trends")
-  
+
   -- Build content
   local lines = {
     "# Startup Time Trends",
@@ -112,7 +112,7 @@ function M.show_trends()
     "## Recent History (last 20)",
     "",
   }
-  
+
   -- Show last 20 entries
   local start_idx = math.max(1, #metrics - 19)
   for i = #metrics, start_idx, -1 do
@@ -124,15 +124,17 @@ function M.show_trends()
     elseif m.startuptime > avg * 1.5 then
       status = "⚠"
     end
-    table.insert(lines, string.format("%s %s  %.2fms  (%d/%d plugins)", 
-      status, date, m.startuptime, m.loaded_count, m.plugin_count))
+    table.insert(
+      lines,
+      string.format("%s %s  %.2fms  (%d/%d plugins)", status, date, m.startuptime, m.loaded_count, m.plugin_count)
+    )
   end
-  
+
   -- Set content
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
   vim.bo[buf].modifiable = false
   vim.bo[buf].filetype = "markdown"
-  
+
   -- Open in split
   vim.cmd("vsplit")
   vim.api.nvim_win_set_buf(0, buf)

--- a/lua/meowvim/theme_manager.lua
+++ b/lua/meowvim/theme_manager.lua
@@ -12,97 +12,97 @@ local function get_current_config()
   if not config_ok then
     return "manual", "catppuccin", "latte", "catppuccin", "mocha", nil
   end
-  
+
   local mode = config.get("core.day_night_mode", "manual")
   local day_theme = config.get("core.day_theme", "catppuccin")
   local day_variant = config.get("core.day_variant", "latte")
   local night_theme = config.get("core.night_theme", "catppuccin")
   local night_variant = config.get("core.night_variant", "mocha")
   local last_preset = config.get("core.last_preset", nil)
-  
+
   return mode, day_theme, day_variant, night_theme, night_variant, last_preset
 end
 
 -- Check if current theme config matches a preset
 local function get_effective_preset()
-  local mode, day_theme, day_variant, night_theme, night_variant, last_preset = get_current_config()
-  
-  -- If no preset was ever set, return nil
+  local _, day_theme, day_variant, night_theme, night_variant, last_preset = get_current_config()
   if not last_preset then
     return nil
   end
-  
+
   -- Check if current config still matches the preset
   local presets_ok, presets_module = pcall(require, "meowvim.day_night_presets")
   if not presets_ok then
     return last_preset
   end
-  
+
   local preset = presets_module.get_preset(last_preset)
   if not preset then
     return nil
   end
-  
+
   -- Compare current config with preset
-  if day_theme == preset.day_theme and 
-     day_variant == preset.day_variant and
-     night_theme == preset.night_theme and
-     night_variant == preset.night_variant then
+  if
+    day_theme == preset.day_theme
+    and day_variant == preset.day_variant
+    and night_theme == preset.night_theme
+    and night_variant == preset.night_variant
+  then
     return last_preset
   end
-  
+
   -- Config doesn't match preset anymore - user customized it
   return "manual"
 end
 
 -- Main theme settings menu
 function M.show_menu()
-  local mode, day_theme, day_variant, night_theme, night_variant, last_preset = get_current_config()
+  local mode, day_theme, day_variant, night_theme, night_variant, _ = get_current_config()
   local effective_preset = get_effective_preset()
-  
+
   local mode_display = mode:gsub("^%l", string.upper)
   local preset_display = effective_preset or "none"
-  
+
   local function format_theme(theme, variant)
     if variant and variant ~= "" then
       return string.format("%s (%s)", theme, variant)
     end
     return theme
   end
-  
+
   local options = {
-    { 
-      id = "preset", 
-      label = "Use preset", 
+    {
+      id = "preset",
+      label = "Use preset",
       value = preset_display,
-      desc = "Choose from 9 ready-made theme pairs" 
+      desc = "Choose from 9 ready-made theme pairs",
     },
-    { 
-      id = "day", 
-      label = "Day theme", 
+    {
+      id = "day",
+      label = "Day theme",
       value = format_theme(day_theme, day_variant),
-      desc = "Light theme for daytime" 
+      desc = "Light theme for daytime",
     },
-    { 
-      id = "night", 
-      label = "Night theme", 
+    {
+      id = "night",
+      label = "Night theme",
       value = format_theme(night_theme, night_variant),
-      desc = "Dark theme for nighttime" 
+      desc = "Dark theme for nighttime",
     },
-    { 
-      id = "mode", 
-      label = "Mode", 
+    {
+      id = "mode",
+      label = "Mode",
       value = mode_display,
-      desc = "Manual toggle or auto-sync with system" 
+      desc = "Manual toggle or auto-sync with system",
     },
   }
-  
+
   local displays = vim.tbl_map(function(opt)
     local max_label_width = 12
     local padding = string.rep(" ", math.max(0, max_label_width - #opt.label))
     return string.format("%s%s: %s", opt.label, padding, opt.value)
   end, options)
-  
+
   vim.ui.select(displays, {
     prompt = "Theme Settings",
     format_item = function(item)
@@ -112,9 +112,9 @@ function M.show_menu()
     if not choice then
       return
     end
-    
+
     local selected = options[idx]
-    
+
     if selected.id == "preset" then
       M.select_preset()
     elseif selected.id == "day" then
@@ -134,7 +134,7 @@ function M.select_preset()
     vim.notify("Presets not available", vim.log.levels.ERROR)
     return
   end
-  
+
   presets.select_preset()
 end
 
@@ -145,7 +145,7 @@ function M.configure_day_theme()
     vim.notify("Day/Night module not available", vim.log.levels.ERROR)
     return
   end
-  
+
   day_night._select_theme_for_slot("day")
 end
 
@@ -156,7 +156,7 @@ function M.configure_night_theme()
     vim.notify("Day/Night module not available", vim.log.levels.ERROR)
     return
   end
-  
+
   day_night._select_theme_for_slot("night")
 end
 
@@ -167,7 +167,7 @@ function M.select_mode()
     vim.notify("Day/Night module not available", vim.log.levels.ERROR)
     return
   end
-  
+
   day_night.select_mode()
 end
 
@@ -178,7 +178,7 @@ function M.quick_toggle()
     vim.notify("Day/Night module not available", vim.log.levels.ERROR)
     return
   end
-  
+
   day_night.toggle()
 end
 

--- a/lua/plugins/conform.lua
+++ b/lua/plugins/conform.lua
@@ -182,7 +182,11 @@ return {
         },
         codespell = {
           condition = function(ctx)
-            return vim.api.nvim_buf_line_count(ctx.bufnr) <= 1000
+            local bufnr = ctx and ctx.bufnr
+            if not bufnr or bufnr == 0 then
+              return false
+            end
+            return vim.api.nvim_buf_line_count(bufnr) <= 1000
           end,
         },
       },

--- a/lua/plugins/copilot.lua
+++ b/lua/plugins/copilot.lua
@@ -10,9 +10,9 @@ return {
     if toggles_ok then
       toggles.ensure("copilot_enabled")
     end
-    
+
     local enabled = vim.g.copilot_enabled or false
-    
+
     require("copilot").setup({
       suggestion = {
         enabled = true,
@@ -48,7 +48,7 @@ return {
         ["."] = false,
       },
     })
-    
+
     if not enabled then
       vim.cmd("Copilot disable")
     end

--- a/lua/plugins/editorconfig.lua
+++ b/lua/plugins/editorconfig.lua
@@ -10,7 +10,7 @@ return {
   init = function()
     -- Let EditorConfig set these values
     vim.g.EditorConfig_exclude_patterns = { "fugitive://.*", "scp://.*" }
-    
+
     -- Don't let EditorConfig override these Neovim-specific settings
     vim.g.EditorConfig_disable_rules = { "trim_trailing_whitespace" }
   end,

--- a/lua/plugins/flash.lua
+++ b/lua/plugins/flash.lua
@@ -8,35 +8,47 @@ return {
   "folke/flash.nvim",
   keys = {
     -- Use 2-character jump mode for f/t/F/T
-    { "f", mode = { "n", "x", "o" }, function() 
+    {
+      "f",
+      mode = { "n", "x", "o" },
+      function()
         require("flash").jump({
           search = { mode = "search", max_length = 2, forward = true, wrap = false },
-        }) 
-      end, 
-      desc = "Flash forward 2-char" 
+        })
+      end,
+      desc = "Flash forward 2-char",
     },
-    { "F", mode = { "n", "x", "o" }, function() 
+    {
+      "F",
+      mode = { "n", "x", "o" },
+      function()
         require("flash").jump({
           search = { mode = "search", max_length = 2, forward = false, wrap = false },
-        }) 
-      end, 
-      desc = "Flash backward 2-char" 
+        })
+      end,
+      desc = "Flash backward 2-char",
     },
-    { "t", mode = { "n", "x", "o" }, function() 
+    {
+      "t",
+      mode = { "n", "x", "o" },
+      function()
         require("flash").jump({
           search = { mode = "search", max_length = 2, forward = true, wrap = false },
           jump = { pos = "end" },
-        }) 
-      end, 
-      desc = "Flash till forward 2-char" 
+        })
+      end,
+      desc = "Flash till forward 2-char",
     },
-    { "T", mode = { "n", "x", "o" }, function() 
+    {
+      "T",
+      mode = { "n", "x", "o" },
+      function()
         require("flash").jump({
           search = { mode = "search", max_length = 2, forward = false, wrap = false },
           jump = { pos = "end" },
-        }) 
-      end, 
-      desc = "Flash till backward 2-char" 
+        })
+      end,
+      desc = "Flash till backward 2-char",
     },
   },
   opts = {
@@ -80,12 +92,12 @@ return {
             [","] = "prev",
           }
         end,
-        search = { 
+        search = {
           wrap = true,
           multi_window = false,
         },
         highlight = { backdrop = true },
-        jump = { 
+        jump = {
           register = false,
           autojump = false,
         },

--- a/lua/plugins/hbac.lua
+++ b/lua/plugins/hbac.lua
@@ -11,16 +11,16 @@ return {
     local config_ok, config = pcall(require, "meowvim.config")
     local threshold = 10 -- Default threshold
     local auto_close_enabled = true -- Default enabled
-    
+
     if config_ok then
       threshold = config.get("performance.buffer_threshold", 10)
       auto_close_enabled = config.get("performance.buffer_auto_close", true)
     end
-    
+
     if not auto_close_enabled then
       return
     end
-    
+
     require("hbac").setup({
       autoclose = true, -- Automatically close unpinned buffers
       threshold = threshold, -- Max number of buffers before auto-close
@@ -29,13 +29,10 @@ return {
       end,
       close_buffers_with_windows = false, -- Don't close buffers with windows
     })
-    
+
     -- Keymaps for buffer pinning
-    vim.keymap.set("n", "<leader>bp", "<cmd>lua require('hbac').toggle_pin()<cr>", 
-      { desc = "Toggle Buffer Pin" })
-    vim.keymap.set("n", "<leader>bP", "<cmd>lua require('hbac').pin_all()<cr>", 
-      { desc = "Pin All Buffers" })
-    vim.keymap.set("n", "<leader>bu", "<cmd>lua require('hbac').unpin_all()<cr>", 
-      { desc = "Unpin All Buffers" })
+    vim.keymap.set("n", "<leader>bp", "<cmd>lua require('hbac').toggle_pin()<cr>", { desc = "Toggle Buffer Pin" })
+    vim.keymap.set("n", "<leader>bP", "<cmd>lua require('hbac').pin_all()<cr>", { desc = "Pin All Buffers" })
+    vim.keymap.set("n", "<leader>bu", "<cmd>lua require('hbac').unpin_all()<cr>", { desc = "Unpin All Buffers" })
   end,
 }

--- a/lua/plugins/lazygit.lua
+++ b/lua/plugins/lazygit.lua
@@ -30,7 +30,7 @@ return {
 
       local theme = config.get("core.theme", "catppuccin")
       local variant = config.get("core.variant", "mocha")
-      
+
       -- Map Neovim themes to LazyGit themes
       local theme_map = {
         catppuccin = {
@@ -45,18 +45,18 @@ return {
         nord = "nord",
         kanagawa = "kanagawa",
       }
-      
+
       local lazygit_theme = theme_map[theme]
       if type(lazygit_theme) == "table" then
         lazygit_theme = lazygit_theme[variant] or lazygit_theme[1]
       end
-      
+
       -- Check if lazygit config exists
       local config_paths = {
         vim.fn.expand("~/.config/lazygit/config.yml"),
         vim.fn.expand("~/.config/jesseduffield/lazygit/config.yml"),
       }
-      
+
       local config_path = nil
       for _, path in ipairs(config_paths) do
         if vim.fn.filereadable(path) == 1 then
@@ -64,20 +64,20 @@ return {
           break
         end
       end
-      
+
       if not config_path then
         -- Create default config if it doesn't exist
         config_path = config_paths[1]
         local config_dir = vim.fn.fnamemodify(config_path, ":h")
         vim.fn.mkdir(config_dir, "p")
       end
-      
+
       -- Read existing config or create new one
       local lines = {}
       if vim.fn.filereadable(config_path) == 1 then
         lines = vim.fn.readfile(config_path)
       end
-      
+
       -- Update or add theme setting
       local theme_found = false
       for i, line in ipairs(lines) do
@@ -87,7 +87,7 @@ return {
           break
         end
       end
-      
+
       if not theme_found then
         -- Add theme to gui section
         local gui_found = false
@@ -98,23 +98,23 @@ return {
             break
           end
         end
-        
+
         if not gui_found then
           table.insert(lines, "gui:")
           table.insert(lines, string.format("  theme: %s", lazygit_theme or "default"))
         end
       end
-      
+
       -- Write config back
       vim.fn.writefile(lines, config_path)
     end
-    
+
     -- Sync theme on LazyGit startup
     vim.api.nvim_create_autocmd("User", {
       pattern = "LazyGitOpen",
       callback = sync_lazygit_theme,
     })
-    
+
     -- Also sync when colorscheme changes
     vim.api.nvim_create_autocmd("ColorScheme", {
       callback = sync_lazygit_theme,

--- a/lua/plugins/lualine.lua
+++ b/lua/plugins/lualine.lua
@@ -102,8 +102,8 @@ return {
         section_separators = { left = "", right = "" },
         ignore_focus = {},
         refresh = {
-          statusline = 50,
-          winbar = 50,
+          statusline = 1000,
+          winbar = 1000,
         },
         always_divide_middle = true,
         globalstatus = true,

--- a/lua/plugins/noice.lua
+++ b/lua/plugins/noice.lua
@@ -36,7 +36,7 @@ return {
         enabled = true,
         format = "lsp_progress",
         format_done = "lsp_progress_done",
-        throttle = 1000 / 30,
+        throttle = 1000 / 10,
         view = "mini",
       },
     },

--- a/lua/plugins/nvim-lint.lua
+++ b/lua/plugins/nvim-lint.lua
@@ -37,7 +37,9 @@ local function collect_linters()
 
   for _, linters in pairs(desired_linters_by_ft) do
     for _, linter in ipairs(linters) do
-      if seen[linter] then goto continue end
+      if seen[linter] then
+        goto continue
+      end
 
       local package = alias_map[linter]
       if package == false then

--- a/lua/plugins/nvim-lspconfig.lua
+++ b/lua/plugins/nvim-lspconfig.lua
@@ -125,29 +125,22 @@ return {
 
     -- Configure global LSP handlers for hover and signature help
     -- These apply to all LSP clients
-    vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(
-      vim.lsp.handlers.hover, 
-      { border = "rounded" }
-    )
-    vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(
-      vim.lsp.handlers.signature_help, 
-      { border = "rounded" }
-    )
+    vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, { border = "rounded" })
+    vim.lsp.handlers["textDocument/signatureHelp"] =
+      vim.lsp.with(vim.lsp.handlers.signature_help, { border = "rounded" })
 
     -- Build capabilities from nvim-cmp defaults
     local caps = require("cmp_nvim_lsp").default_capabilities()
     -- Enable semantic tokens (supported in Neovim 0.11+)
     -- Semantic tokens provide enhanced syntax highlighting based on LSP semantic information
     -- See :h lsp-semantic-highlight for more details
-    caps.textDocument.semanticTokens = vim.tbl_deep_extend("force", 
-      caps.textDocument.semanticTokens or {},
-      { dynamicRegistration = true }
-    )
+    caps.textDocument.semanticTokens =
+      vim.tbl_deep_extend("force", caps.textDocument.semanticTokens or {}, { dynamicRegistration = true })
 
     local on_attach = function(client, bufnr)
       -- Note: Neovim 0.11+ sets omnifunc automatically as a buffer-local default
       -- Only override if you need custom behavior
-      
+
       -- Enable inlay hints for supported servers (gopls, rust-analyzer, ts_ls, etc.)
       -- Provides inline type information and parameter names
       if client.server_capabilities.inlayHintProvider then
@@ -200,10 +193,10 @@ return {
       gopls = {
         -- Neovim 0.11+ root_dir signature: function(bufnr, on_dir)
         root_dir = function(bufnr, on_dir)
-          local root = vim.fs.root(bufnr, { 'go.work', 'go.mod', '.git' })
+          local root = vim.fs.root(bufnr, { "go.work", "go.mod", ".git" })
           on_dir(root or vim.fs.dirname(vim.api.nvim_buf_get_name(bufnr)))
         end,
-        filetypes = { 'go', 'gomod', 'gowork', 'gotmpl' },
+        filetypes = { "go", "gomod", "gowork", "gotmpl" },
         settings = {
           gopls = {
             gofumpt = true,
@@ -358,7 +351,7 @@ return {
       local custom_on_attach = server_opts.on_attach
 
       server_opts.capabilities = vim.tbl_deep_extend("force", {}, caps, server_opts.capabilities or {})
-      
+
       -- Merge on_attach callbacks
       local base_on_attach = on_attach
       server_opts.on_attach = function(client, bufnr)
@@ -371,30 +364,27 @@ return {
       -- Get default config from nvim-lspconfig to extract cmd, filetypes, etc.
       local server = lspconfig[server_name]
       if not server or not server.document_config then
-        vim.notify(
-          string.format("LSP server '%s' not found in lspconfig", server_name),
-          vim.log.levels.WARN
-        )
+        vim.notify(string.format("LSP server '%s' not found in lspconfig", server_name), vim.log.levels.WARN)
         return
       end
 
       local default_config = server.document_config.default_config or {}
-      
+
       -- Build the final config by merging defaults with custom settings
       local common_root_markers = {
-        'package.json',
-        'tsconfig.json',
-        'jsconfig.json',
-        'pyproject.toml',
-        'setup.py',
-        'requirements.txt',
-        'go.mod',
-        'Cargo.toml',
-        'pom.xml',
-        'build.gradle',
-        '.git',
+        "package.json",
+        "tsconfig.json",
+        "jsconfig.json",
+        "pyproject.toml",
+        "setup.py",
+        "requirements.txt",
+        "go.mod",
+        "Cargo.toml",
+        "pom.xml",
+        "build.gradle",
+        ".git",
       }
-      
+
       -- Build final config: start with defaults, layer common root_markers,
       -- then overlay any per-server overrides (server_opts may include a
       -- root_dir function using the Neovim 0.11+ (bufnr, on_dir) signature,
@@ -407,7 +397,7 @@ return {
         -- unless a server needs custom logic (e.g. gopls -- see server_settings).
         root_markers = common_root_markers,
       }, server_opts)
-      
+
       -- Use Neovim 0.11+ native LSP API
       vim.lsp.config(server_name, final_config)
       vim.lsp.enable(server_name)
@@ -422,18 +412,18 @@ return {
     do
       if lspconfig.gdscript and lspconfig.gdscript.document_config then
         local default_config = lspconfig.gdscript.document_config.default_config or {}
-        vim.lsp.config('gdscript', {
+        vim.lsp.config("gdscript", {
           cmd = default_config.cmd,
           filetypes = default_config.filetypes,
           -- Neovim 0.11+ root_dir signature: function(bufnr, on_dir)
           root_dir = function(bufnr, on_dir)
-            local root = vim.fs.root(bufnr, { 'project.godot', '.git' })
+            local root = vim.fs.root(bufnr, { "project.godot", ".git" })
             on_dir(root or vim.fs.dirname(vim.api.nvim_buf_get_name(bufnr)))
           end,
           capabilities = caps,
           on_attach = on_attach,
         })
-        vim.lsp.enable('gdscript')
+        vim.lsp.enable("gdscript")
       end
     end
 

--- a/lua/plugins/nvim-treesitter-context.lua
+++ b/lua/plugins/nvim-treesitter-context.lua
@@ -12,7 +12,7 @@ return {
     max_lines = 3,
     min_window_height = 10,
     line_numbers = true,
-    mode = "cursor",
+    mode = "topline",
     trim_scope = "outer",
     separator = nil,
     zindex = 20,

--- a/lua/plugins/persistence.lua
+++ b/lua/plugins/persistence.lua
@@ -8,23 +8,36 @@ return {
   "folke/persistence.nvim",
   event = "BufReadPre",
   keys = {
-    { "<leader>qs", function() require("persistence").load() end, desc = "Restore Session" },
-    { "<leader>qS", function() require("persistence").select() end, desc = "Select Session" },
-    { "<leader>ql", function() require("persistence").load({ last = true }) end, desc = "Restore Last Session" },
-    { "<leader>qd", function() require("persistence").stop() end, desc = "Don't Save Current Session" },
+    {
+      "<leader>qs",
+      function()
+        require("persistence").load()
+      end,
+      desc = "Restore Session",
+    },
+    {
+      "<leader>qS",
+      function()
+        require("persistence").select()
+      end,
+      desc = "Select Session",
+    },
+    {
+      "<leader>ql",
+      function()
+        require("persistence").load({ last = true })
+      end,
+      desc = "Restore Last Session",
+    },
+    {
+      "<leader>qd",
+      function()
+        require("persistence").stop()
+      end,
+      desc = "Don't Save Current Session",
+    },
   },
   opts = function()
-    local config_ok, config = pcall(require, "meowvim.config")
-    local per_branch = false
-    local auto_save = true
-    local auto_restore = true
-    
-    if config_ok then
-      per_branch = config.get("sessions.per_branch", false)
-      auto_save = config.get("sessions.auto_save", true)
-      auto_restore = config.get("sessions.auto_restore", true)
-    end
-    
     return {
       options = {
         "buffers",
@@ -32,14 +45,12 @@ return {
         "folds",
         "globals",
         "tabpages",
-        "winpos",
-        "winsize",
         "localoptions",
       },
       pre_save = function()
         -- Close certain plugin windows before saving
         vim.api.nvim_exec_autocmds("User", { pattern = "SessionSavePre" })
-        
+
         -- Close NvimTree, aerial, and other plugin windows
         local close_filetypes = { "NvimTree", "neo-tree", "aerial", "Outline", "trouble" }
         for _, win in ipairs(vim.api.nvim_list_wins()) do
@@ -55,13 +66,13 @@ return {
   config = function(_, opts)
     local persistence = require("persistence")
     persistence.setup(opts)
-    
+
     -- Get configuration
     local config_ok, config = pcall(require, "meowvim.config")
     local per_branch = config_ok and config.get("sessions.per_branch", false) or false
     local auto_save = config_ok and config.get("sessions.auto_save", true) or true
     local auto_restore = config_ok and config.get("sessions.auto_restore", true) or true
-    
+
     -- Auto-save session on directory change
     if auto_save then
       vim.api.nvim_create_autocmd("DirChanged", {
@@ -74,17 +85,19 @@ return {
         end,
       })
     end
-    
+
     -- Per-branch session support
     if per_branch then
       local function get_git_branch()
         local handle = io.popen("git rev-parse --abbrev-ref HEAD 2>/dev/null")
-        if not handle then return nil end
+        if not handle then
+          return nil
+        end
         local branch = handle:read("*a")
         handle:close()
         return branch and branch:gsub("\n", "") or nil
       end
-      
+
       -- Override session file name to include branch
       local original_save = persistence.save
       persistence.save = function()
@@ -96,7 +109,7 @@ return {
         original_save()
       end
     end
-    
+
     -- Auto-restore session on VimEnter
     if auto_restore then
       vim.api.nvim_create_autocmd("VimEnter", {

--- a/lua/plugins/snacks.lua
+++ b/lua/plugins/snacks.lua
@@ -162,8 +162,7 @@ return {
       notifier = {},
       terminal = {},
       image = {
-        enabled = image_preview,
-        backend = "kitty",
+        enabled = image_preview and not vim.env.ZELLIJ,
       },
       scope = {
         enabled = scope_highlighting,

--- a/lua/plugins/snacks.lua
+++ b/lua/plugins/snacks.lua
@@ -4,25 +4,112 @@
 -- @file: lua/plugins/snacks.lua
 -- @brief: Collection of useful utilities and UI components.
 
+-- luacheck: globals Snacks
+
 return {
   "folke/snacks.nvim",
   version = "v2.*", -- Pin to stable 2.x releases
+  priority = 1000,
   lazy = false,
   keys = {
-    { "<leader>.",  function() Snacks.scratch() end, desc = "Toggle Scratch Buffer" },
-    { "<leader>Ns", function() Snacks.scratch.select() end, desc = "Select Scratch Buffer" },
-    { "<leader>hn", function() Snacks.notifier.show_history() end, desc = "Notification History" },
-    { "<leader>bd", function() Snacks.bufdelete() end, desc = "Delete Buffer" },
-    { "<leader>gg", function() Snacks.lazygit() end, desc = "Lazygit" },
-    { "<leader>gb", function() Snacks.git.blame_line() end, desc = "Git Blame Line" },
-    { "<leader>gB", function() Snacks.gitbrowse() end, desc = "Git Browse" },
-    { "<leader>gf", function() Snacks.lazygit.log_file() end, desc = "Lazygit Current File History" },
-    { "<leader>gl", function() Snacks.lazygit.log() end, desc = "Lazygit Log" },
-    { "<leader>cR", function() Snacks.rename() end, desc = "Rename File" },
-    { "<c-/>",      function() Snacks.terminal() end, desc = "Toggle Terminal" },
-    { "<c-_>",      function() Snacks.terminal() end, desc = "Toggle Terminal (which-key)" },
-    { "]w",         function() Snacks.words.jump(vim.v.count1) end, desc = "Next Reference" },
-    { "[w",         function() Snacks.words.jump(-vim.v.count1) end, desc = "Prev Reference" },
+    {
+      "<leader>.",
+      function()
+        Snacks.scratch()
+      end,
+      desc = "Toggle Scratch Buffer",
+    },
+    {
+      "<leader>Ns",
+      function()
+        Snacks.scratch.select()
+      end,
+      desc = "Select Scratch Buffer",
+    },
+    {
+      "<leader>hn",
+      function()
+        Snacks.notifier.show_history()
+      end,
+      desc = "Notification History",
+    },
+    {
+      "<leader>bd",
+      function()
+        Snacks.bufdelete()
+      end,
+      desc = "Delete Buffer",
+    },
+    {
+      "<leader>gg",
+      function()
+        Snacks.lazygit()
+      end,
+      desc = "Lazygit",
+    },
+    {
+      "<leader>gb",
+      function()
+        Snacks.git.blame_line()
+      end,
+      desc = "Git Blame Line",
+    },
+    {
+      "<leader>gB",
+      function()
+        Snacks.gitbrowse()
+      end,
+      desc = "Git Browse",
+    },
+    {
+      "<leader>gf",
+      function()
+        Snacks.lazygit.log_file()
+      end,
+      desc = "Lazygit Current File History",
+    },
+    {
+      "<leader>gl",
+      function()
+        Snacks.lazygit.log()
+      end,
+      desc = "Lazygit Log",
+    },
+    {
+      "<leader>cR",
+      function()
+        Snacks.rename()
+      end,
+      desc = "Rename File",
+    },
+    {
+      "<c-/>",
+      function()
+        Snacks.terminal()
+      end,
+      desc = "Toggle Terminal",
+    },
+    {
+      "<c-_>",
+      function()
+        Snacks.terminal()
+      end,
+      desc = "Toggle Terminal (which-key)",
+    },
+    {
+      "]w",
+      function()
+        Snacks.words.jump(vim.v.count1)
+      end,
+      desc = "Next Reference",
+    },
+    {
+      "[w",
+      function()
+        Snacks.words.jump(-vim.v.count1)
+      end,
+      desc = "Prev Reference",
+    },
   },
   config = function(_, opts)
     require("snacks").setup(opts)
@@ -37,179 +124,179 @@ return {
     local image_preview = true
     local scope_highlighting = true
     local custom_styles = true
-    
+
     if config_ok then
       image_preview = config.get("snacks.image_preview", true)
       scope_highlighting = config.get("snacks.scope_highlighting", true)
       custom_styles = config.get("snacks.custom_styles", true)
     end
-    
+
     return {
-    dashboard = {
-      width = 52,
-      preset = {
-        keys = {
-          { icon = " ", key = "p", desc = "Open Project", action = ":lua Snacks.dashboard.pick('projects')" },
-          { icon = " ", key = "n", desc = "Create File", action = ":ene | startinsert" },
-          { icon = " ", key = "f", desc = "Find File", action = ":lua Snacks.dashboard.pick('files')" },
-          { icon = " ", key = "r", desc = "Show Recent Files", action = ":lua Snacks.dashboard.pick('oldfiles')" },
-          { icon = " ", key = "q", desc = "Quit Neovim", action = ":qa" },
-        },
-        header = [[meowvim
+      dashboard = {
+        width = 52,
+        preset = {
+          keys = {
+            { icon = " ", key = "p", desc = "Open Project", action = ":lua Snacks.dashboard.pick('projects')" },
+            { icon = " ", key = "n", desc = "Create File", action = ":ene | startinsert" },
+            { icon = " ", key = "f", desc = "Find File", action = ":lua Snacks.dashboard.pick('files')" },
+            { icon = " ", key = "r", desc = "Show Recent Files", action = ":lua Snacks.dashboard.pick('oldfiles')" },
+            { icon = " ", key = "q", desc = "Quit Neovim", action = ":qa" },
+          },
+          header = [[meowvim
 -------]],
+        },
+        sections = {
+          { section = "header", padding = 1 },
+          { section = "projects", padding = 1 },
+          { section = "keys", gap = 0, padding = 1 },
+          { section = "startup", padding = 1 },
+        },
       },
-      sections = {
-        { section = "header", padding = 1 },
-        { section = "projects", padding = 1 },
-        { section = "keys", gap = 0, padding = 1 },
-        { section = "startup", padding = 1 },
-      },
-    },
 
-    bigfile = {},
-    dim = {},
-    explorer = {
-      replace_netrw = true,
-    },
-    input = {},
-    notifier = {},
-    terminal = {},
-    image = {
-      enabled = image_preview,
-      backend = "kitty",
-    },
-    scope = {
-      enabled = scope_highlighting,
-      treesitter = {
-        enabled = true,
+      bigfile = {},
+      dim = {},
+      explorer = {
+        replace_netrw = true,
       },
-    },
-    scratch = {
-      ft = "markdown",
-      filekey = {
-        cwd = true,
-        branch = false,
-        count = true,
+      input = {},
+      notifier = {},
+      terminal = {},
+      image = {
+        enabled = image_preview,
+        backend = "kitty",
       },
-    },
-    styles = {
-      enabled = custom_styles,
-      notification = {
-        wo = {
-          winblend = 0,
-          wrap = false,
+      scope = {
+        enabled = scope_highlighting,
+        treesitter = {
+          enabled = true,
         },
       },
-    },
-
-    picker = {
-      hidden = true,
-      layout = { preset = "ivy" },
-      sources = {
-        files = {
-          hidden = true,
+      scratch = {
+        ft = "markdown",
+        filekey = {
+          cwd = true,
+          branch = false,
+          count = true,
         },
-        git_files = {
-          hidden = true,
-        },
-        recent = {
-          hidden = true,
-        },
-        explorer = {
-          layout = {
-            position = "right",
-          },
-          hidden = true,
-          follow_file = true,
-          auto_close = true,
-          jump = {
-            close = true,
+      },
+      styles = {
+        enabled = custom_styles,
+        notification = {
+          wo = {
+            winblend = 0,
+            wrap = false,
           },
         },
-        projects = {
-          hidden = true,
-          dev = {
-            "~/workspace",
-            "~/dev",
-            "~/projects",
+      },
+
+      picker = {
+        hidden = true,
+        layout = { preset = "ivy" },
+        sources = {
+          files = {
+            hidden = true,
           },
-          -- Configured projects from ~/.config/meowvim/projects.lua
-          projects = (function()
-            local ok, config = pcall(require, "meowvim.config")
-            if ok then
-              return config.get_project_paths()
-            end
-            return {}
-          end)(),
-          -- Only scan for git repos in dev dirs, configured projects are always shown first
-          patterns = { ".git" },
-          -- Include recent projects from vim history
-          recent = true,
-          confirm = function(picker, item)
-            picker:close()
-            if not item or not item.file then
-              return
-            end
-
-            local dir = item.file
-            local session_utils = require("utils.session")
-
-            session_utils.save()
-
-            local session_loaded = false
-            vim.api.nvim_create_autocmd("SessionLoadPost", {
-              once = true,
-              callback = function()
-                session_loaded = true
-              end,
-            })
-
-            vim.defer_fn(function()
-              if not session_loaded then
-                require("snacks").picker.files()
+          git_files = {
+            hidden = true,
+          },
+          recent = {
+            hidden = true,
+          },
+          explorer = {
+            layout = {
+              position = "right",
+            },
+            hidden = true,
+            follow_file = true,
+            auto_close = true,
+            jump = {
+              close = true,
+            },
+          },
+          projects = {
+            hidden = true,
+            dev = {
+              "~/workspace",
+              "~/dev",
+              "~/projects",
+            },
+            -- Configured projects from ~/.config/meowvim/projects.lua
+            projects = (function()
+              local ok, cfg = pcall(require, "meowvim.config")
+              if ok then
+                return cfg.get_project_paths()
               end
-            end, 100)
-
-            session_utils.reset()
-
-            vim.fn.chdir(dir)
-
-            -- Detect and apply project-specific settings, run on_open command
-            local ok, config = pcall(require, "meowvim.config")
-            if ok then
-              local current_project = config.detect_current_project()
-              if current_project and current_project.on_open then
-                vim.defer_fn(function()
-                  vim.cmd(current_project.on_open)
-                end, 150)
+              return {}
+            end)(),
+            -- Only scan for git repos in dev dirs, configured projects are always shown first
+            patterns = { ".git" },
+            -- Include recent projects from vim history
+            recent = true,
+            confirm = function(picker, item)
+              picker:close()
+              if not item or not item.file then
+                return
               end
-            end
 
-            local session = require("snacks").dashboard.sections.session()
-            if not session then
-              return
-            end
+              local dir = item.file
+              local session_utils = require("utils.session")
 
-            local action = session.action
-            if type(action) == "function" then
-              action()
-              return
-            end
+              session_utils.save()
 
-            if type(action) == "string" then
-              if action:sub(1, 1) == ":" then
-                vim.cmd(action:sub(2))
-              else
-                vim.cmd(action)
+              local session_loaded = false
+              vim.api.nvim_create_autocmd("SessionLoadPost", {
+                once = true,
+                callback = function()
+                  session_loaded = true
+                end,
+              })
+
+              vim.defer_fn(function()
+                if not session_loaded then
+                  require("snacks").picker.files()
+                end
+              end, 100)
+
+              session_utils.reset()
+
+              vim.fn.chdir(dir)
+
+              -- Detect and apply project-specific settings, run on_open command
+              local ok, cfg = pcall(require, "meowvim.config")
+              if ok then
+                local current_project = cfg.detect_current_project()
+                if current_project and current_project.on_open then
+                  vim.defer_fn(function()
+                    vim.cmd(current_project.on_open)
+                  end, 150)
+                end
               end
-            end
-          end,
-        },
-        lsp_workspace_symbols = {
-          tree = true,
+
+              local session = require("snacks").dashboard.sections.session()
+              if not session then
+                return
+              end
+
+              local action = session.action
+              if type(action) == "function" then
+                action()
+                return
+              end
+
+              if type(action) == "string" then
+                if action:sub(1, 1) == ":" then
+                  vim.cmd(action:sub(2))
+                else
+                  vim.cmd(action)
+                end
+              end
+            end,
+          },
+          lsp_workspace_symbols = {
+            tree = true,
+          },
         },
       },
-    },
-  }
+    }
   end,
 }

--- a/lua/plugins/themes.lua
+++ b/lua/plugins/themes.lua
@@ -7,9 +7,7 @@
 local function get_config_theme()
   local ok, config = pcall(require, "meowvim.config")
   if ok then
-    return config.get("core.theme", "catppuccin"), 
-           config.get("core.variant", "mocha"),
-           config.get("ui.transparency", 0)
+    return config.get("core.theme", "catppuccin"), config.get("core.variant", "mocha"), config.get("ui.transparency", 0)
   end
   return "catppuccin", "mocha", 0
 end
@@ -22,7 +20,7 @@ local catppuccin = {
   lazy = false,
   config = function()
     local theme, variant, transparency = get_config_theme()
-    
+
     if theme ~= "catppuccin" then
       return
     end
@@ -51,13 +49,12 @@ local catppuccin = {
         gitsigns = true,
       },
     })
-    
+
     vim.g.catppuccin_flavour = variant
     vim.cmd.colorscheme("catppuccin")
-    
+
     -- Apply transparency level if > 0
     if transparency > 0 then
-      local alpha = 100 - transparency
       vim.api.nvim_set_hl(0, "Normal", { bg = "NONE" })
       vim.api.nvim_set_hl(0, "NormalFloat", { bg = "NONE" })
       vim.api.nvim_set_hl(0, "NormalNC", { bg = "NONE" })
@@ -72,7 +69,7 @@ local tokyonight = {
   lazy = false,
   config = function()
     local theme, variant, transparency = get_config_theme()
-    
+
     if theme ~= "tokyonight" then
       return
     end
@@ -90,7 +87,7 @@ local tokyonight = {
         floats = transparency > 0 and "transparent" or "dark",
       },
     })
-    
+
     vim.cmd.colorscheme("tokyonight")
   end,
 }
@@ -103,7 +100,7 @@ local rose_pine = {
   lazy = false,
   config = function()
     local theme, variant, transparency = get_config_theme()
-    
+
     if theme ~= "rose-pine" then
       return
     end
@@ -120,7 +117,7 @@ local rose_pine = {
         transparency = transparency > 0,
       },
     })
-    
+
     vim.cmd.colorscheme("rose-pine")
   end,
 }
@@ -132,7 +129,7 @@ local gruvbox = {
   lazy = false,
   config = function()
     local theme, variant, transparency = get_config_theme()
-    
+
     if theme ~= "gruvbox" then
       return
     end
@@ -152,7 +149,7 @@ local gruvbox = {
       contrast = variant or "medium", -- hard, medium, soft
       transparent_mode = transparency > 0,
     })
-    
+
     vim.o.background = "dark"
     vim.cmd.colorscheme("gruvbox")
   end,
@@ -165,7 +162,7 @@ local nord = {
   lazy = false,
   config = function()
     local theme, _, transparency = get_config_theme()
-    
+
     if theme ~= "nord" then
       return
     end
@@ -175,7 +172,7 @@ local nord = {
     vim.g.nord_disable_background = transparency > 0
     vim.g.nord_italic = true
     vim.g.nord_bold = true
-    
+
     vim.cmd.colorscheme("nord")
   end,
 }
@@ -187,7 +184,7 @@ local kanagawa = {
   lazy = false,
   config = function()
     local theme, variant, transparency = get_config_theme()
-    
+
     if theme ~= "kanagawa" then
       return
     end
@@ -205,7 +202,7 @@ local kanagawa = {
       terminalColors = true,
       theme = variant or "wave", -- wave, dragon, lotus
     })
-    
+
     vim.cmd.colorscheme("kanagawa")
   end,
 }
@@ -217,7 +214,7 @@ local everforest = {
   lazy = false,
   config = function()
     local theme, variant, transparency = get_config_theme()
-    
+
     if theme ~= "everforest" then
       return
     end
@@ -226,7 +223,7 @@ local everforest = {
     -- Variants: hard, medium, soft for both dark and light backgrounds
     local background = "dark"
     local style = "medium"
-    
+
     if variant then
       if variant:match("^light") then
         background = "light"
@@ -255,7 +252,7 @@ local everforest = {
       show_eob = true,
       float_style = "bright",
     })
-    
+
     vim.o.background = background
     vim.cmd.colorscheme("everforest")
   end,
@@ -268,7 +265,7 @@ local nightfox = {
   lazy = false,
   config = function()
     local theme, variant, transparency = get_config_theme()
-    
+
     if theme ~= "nightfox" then
       return
     end
@@ -285,7 +282,7 @@ local nightfox = {
         },
       },
     })
-    
+
     -- Variants: nightfox, dayfox, dawnfox, duskfox, nordfox, terafox, carbonfox
     vim.cmd.colorscheme(variant or "nightfox")
   end,
@@ -299,7 +296,7 @@ local zenbones = {
   dependencies = { "rktjmp/lush.nvim" },
   config = function()
     local theme, variant, transparency = get_config_theme()
-    
+
     if theme ~= "zenbones" then
       return
     end
@@ -308,8 +305,8 @@ local zenbones = {
     if transparency > 0 then
       vim.g.zenbones_transparent_background = true
     end
-    
-    -- Variants: zenbones, zenwritten, neobones, tokyobones, seoulbones, 
+
+    -- Variants: zenbones, zenwritten, neobones, tokyobones, seoulbones,
     --           forestbones, nordbones, kanagawabones, rosebones
     vim.cmd.colorscheme(variant or "zenbones")
   end,
@@ -322,7 +319,7 @@ local solarized_osaka = {
   lazy = false,
   config = function()
     local theme, variant, transparency = get_config_theme()
-    
+
     if theme ~= "solarized-osaka" then
       return
     end
@@ -341,7 +338,7 @@ local solarized_osaka = {
       -- Variants: storm (dark), night (darker), moon (darkest), day (light)
       style = variant or "night",
     })
-    
+
     vim.cmd.colorscheme("solarized-osaka")
   end,
 }
@@ -353,7 +350,7 @@ local ayu = {
   lazy = false,
   config = function()
     local theme, variant, transparency = get_config_theme()
-    
+
     if theme ~= "ayu" then
       return
     end
@@ -373,7 +370,7 @@ local ayu = {
         VertSplit = { bg = "None" },
       } or {},
     })
-    
+
     -- Set background before applying colorscheme
     -- Variants: dark, light, mirage
     if variant == "light" then
@@ -381,7 +378,7 @@ local ayu = {
     else
       vim.o.background = "dark"
     end
-    
+
     vim.cmd.colorscheme("ayu")
   end,
 }
@@ -393,7 +390,7 @@ local dracula = {
   lazy = false,
   config = function()
     local theme, _, transparency = get_config_theme()
-    
+
     if theme ~= "dracula" then
       return
     end
@@ -402,7 +399,7 @@ local dracula = {
       transparent_bg = transparency > 0,
       italic_comment = true,
     })
-    
+
     vim.cmd.colorscheme("dracula")
   end,
 }
@@ -414,7 +411,7 @@ local monokai_pro = {
   lazy = false,
   config = function()
     local theme, variant, transparency = get_config_theme()
-    
+
     if theme ~= "monokai-pro" then
       return
     end
@@ -435,7 +432,7 @@ local monokai_pro = {
       },
       filter = variant or "pro", -- pro, octagon, machine, ristretto, spectrum, classic
     })
-    
+
     vim.cmd.colorscheme("monokai-pro")
   end,
 }
@@ -447,7 +444,7 @@ local onedark = {
   lazy = false,
   config = function()
     local theme, variant, transparency = get_config_theme()
-    
+
     if theme ~= "onedark" then
       return
     end
@@ -467,7 +464,7 @@ local onedark = {
         variables = "NONE",
       },
     })
-    
+
     -- Variants: onedark, onelight, onedark_vivid, onedark_dark
     vim.cmd.colorscheme(variant or "onedark")
   end,
@@ -480,7 +477,7 @@ local material = {
   lazy = false,
   config = function()
     local theme, variant, transparency = get_config_theme()
-    
+
     if theme ~= "material" then
       return
     end
@@ -522,7 +519,7 @@ local material = {
       lualine_style = "default",
       async_loading = true,
     })
-    
+
     -- Variants: darker, lighter, oceanic, palenight, deep ocean
     vim.g.material_style = variant or "darker"
     vim.cmd.colorscheme("material")
@@ -536,7 +533,7 @@ local melange = {
   lazy = false,
   config = function()
     local theme, _, transparency = get_config_theme()
-    
+
     if theme ~= "melange" then
       return
     end
@@ -550,7 +547,7 @@ local melange = {
         end,
       })
     end
-    
+
     vim.cmd.colorscheme("melange")
   end,
 }
@@ -562,7 +559,7 @@ local github = {
   lazy = false,
   config = function()
     local theme, variant, transparency = get_config_theme()
-    
+
     if theme ~= "github" then
       return
     end
@@ -579,7 +576,7 @@ local github = {
         },
       },
     })
-    
+
     -- Variants: github_dark, github_dark_dimmed, github_dark_high_contrast,
     --           github_light, github_light_high_contrast, github_dark_colorblind,
     --           github_light_colorblind, github_dark_tritanopia, github_light_tritanopia

--- a/lua/utils/session.lua
+++ b/lua/utils/session.lua
@@ -12,7 +12,7 @@ local function close_floating_windows()
       end
     end
   end)
-  
+
   if not ok then
     vim.notify("Error closing floating windows: " .. tostring(err), vim.log.levels.WARN)
   end
@@ -26,7 +26,7 @@ local function wipe_listed_buffers()
       end
     end
   end)
-  
+
   if not ok then
     vim.notify("Error wiping buffers: " .. tostring(err), vim.log.levels.WARN)
   end
@@ -81,7 +81,7 @@ function M.reset()
       vim.cmd("enew")
     end
   end)
-  
+
   if not ok then
     vim.notify("Error resetting session: " .. tostring(err), vim.log.levels.ERROR)
     return false

--- a/lua/utils/toggles.lua
+++ b/lua/utils/toggles.lua
@@ -2,13 +2,41 @@
 -- Utility helpers for keeping toggle state in sync with session data and config.
 
 local registry = {
-  disable_autoformat = { store = "DisableAutoFormat", default = true, type = "boolean", config_key = "toggles.autoformat", invert = true },
-  disable_autosave = { store = "DisableAutoSave", default = false, type = "boolean", config_key = "toggles.autosave", invert = true },
-  miniindentscope_disable = { store = "MiniIndentscopeDisable", default = true, type = "boolean", config_key = "toggles.mini_indentscope", invert = true },
+  disable_autoformat = {
+    store = "DisableAutoFormat",
+    default = true,
+    type = "boolean",
+    config_key = "toggles.autoformat",
+    invert = true,
+  },
+  disable_autosave = {
+    store = "DisableAutoSave",
+    default = false,
+    type = "boolean",
+    config_key = "toggles.autosave",
+    invert = true,
+  },
+  miniindentscope_disable = {
+    store = "MiniIndentscopeDisable",
+    default = true,
+    type = "boolean",
+    config_key = "toggles.mini_indentscope",
+    invert = true,
+  },
   snacks_dim = { store = "SnacksDim", default = false, type = "boolean", config_key = "toggles.snacks_dim" },
   lint_enabled = { store = "LintEnabled", default = true, type = "boolean", config_key = "toggles.lint" },
-  diagnostics_enabled = { store = "DiagnosticsEnabled", default = true, type = "boolean", config_key = "toggles.diagnostics" },
-  inlay_hints_enabled = { store = "InlayHintsEnabled", default = false, type = "boolean", config_key = "toggles.inlay_hints" },
+  diagnostics_enabled = {
+    store = "DiagnosticsEnabled",
+    default = true,
+    type = "boolean",
+    config_key = "toggles.diagnostics",
+  },
+  inlay_hints_enabled = {
+    store = "InlayHintsEnabled",
+    default = false,
+    type = "boolean",
+    config_key = "toggles.inlay_hints",
+  },
   copilot_enabled = { store = "CopilotEnabled", default = false, type = "boolean", config_key = "toggles.copilot" },
   -- Vim option toggles
   number_mode = { store = "NumberMode", default = "relative", type = "string", config_key = "toggles.number_mode" }, -- "off", "number", "relative"
@@ -77,7 +105,7 @@ local function get_default_value(name)
   if not meta then
     return nil
   end
-  
+
   -- Try to get from config first
   if meta.config_key then
     local ok, config = pcall(require, "meowvim.config")
@@ -92,7 +120,7 @@ local function get_default_value(name)
       end
     end
   end
-  
+
   return meta.default
 end
 
@@ -141,7 +169,7 @@ function M.sync_to_config()
   if not ok then
     return false
   end
-  
+
   for name, meta in pairs(registry) do
     if meta.config_key and vim.g[name] ~= nil then
       local value = vim.g[name]
@@ -152,7 +180,7 @@ function M.sync_to_config()
       config.set(meta.config_key, value)
     end
   end
-  
+
   return true
 end
 


### PR DESCRIPTION
## Summary

- Disable all Neovim providers (Python3, Ruby, Perl, Node) since no plugins require them, eliminating health warnings
- Fix partial-redraw glitches under Zellij and other multiplexers by adding a `VimResized` autocmd that forces a full redraw
- Disable image preview when running inside Zellij (Kitty protocol unsupported) and remove hardcoded `backend = "kitty"`
- Tune default options: disable `mousefocus`, set `pumblend = 0`, trim `sessionoptions` to avoid state-restore issues
- Apply StyLua formatting across the entire codebase for consistency
- Improve `bin/test-config.sh` keymap-conflict test to capture headless output reliably